### PR TITLE
feat: auto-register codecs at worker & stub creation sites

### DIFF
--- a/core/src/main/scala/zio/temporal/activity/ZActivityImplementationObject.scala
+++ b/core/src/main/scala/zio/temporal/activity/ZActivityImplementationObject.scala
@@ -1,14 +1,32 @@
 package zio.temporal.activity
 
 import zio._
+import zio.temporal.json.CodecRegistry
 
 /** Type-safe wrapper of activity implementation object. The wrapper can be constructed only if the wrapped object is a
   * correct activity implementation.
   *
+  * Carries a `registerCodecs` thunk captured at construction time — when the element type `T` is still known to the
+  * compiler — so that `ZWorker.addActivityImplementations(List[ZActivityImplementationObject[_]])` can auto-register
+  * codecs for each activity interface without needing the element types back. The thunk is a no-op when the worker's
+  * registry is `None` (user opted out via `withDataConverter(raw)`).
+  *
   * @param value
   *   the activity implementation object
+  * @param registerCodecs
+  *   closure that, when invoked with the worker's registry option, registers every codec required by each
+  *   `@activityInterface`-annotated supertype of `T`. Built at compile time by the macro in
+  *   `ZActivityImplementationObject.apply[T]`.
   */
-final class ZActivityImplementationObject[T <: AnyRef] private[zio] (val value: T) {
+final class ZActivityImplementationObject[T <: AnyRef] private[zio] (
+  val value:                          T,
+  private[zio] val registerCodecs: Option[CodecRegistry] => Unit) {
+
+  /** Secondary no-op constructor for binary compatibility with legacy callers that don't build via
+    * `ZActivityImplementationObject[T](value)`. Auto-registration is skipped for impls constructed this way.
+    */
+  private[zio] def this(value: T) = this(value, _ => ())
+
   override def toString: String = {
     s"ZActivityImplementation(value=$value)"
   }
@@ -28,7 +46,18 @@ final class ZActivityImplementationObject[T <: AnyRef] private[zio] (val value: 
 
 object ZActivityImplementationObject {
 
+  /** Internal builder used by the inline `apply` — needed because Scala 3 forbids inline methods from calling
+    * `private[zio]` constructors directly. Users should use [[apply]].
+    */
+  @zio.temporal.internalApi
+  def build[T <: AnyRef](value: T, registerCodecs: Option[CodecRegistry] => Unit): ZActivityImplementationObject[T] =
+    new ZActivityImplementationObject[T](value, registerCodecs)
+
   /** Constructs the wrapper.
+    *
+    * The `inline` keyword + macro-expanded codec registration is what lets the wrapper carry a deferred thunk that
+    * still knows `T`'s activity interface even after `T` is erased to `AnyRef` inside a
+    * `List[ZActivityImplementationObject[_]]`.
     *
     * @tparam T
     *   activity type.
@@ -38,15 +67,18 @@ object ZActivityImplementationObject {
     * @return
     *   [[ZActivityImplementationObject]]
     */
-  def apply[T <: AnyRef: ExtendsActivity](value: T): ZActivityImplementationObject[T] =
-    new ZActivityImplementationObject[T](value)
+  inline def apply[T <: AnyRef: ExtendsActivity](value: T): ZActivityImplementationObject[T] =
+    build[T](
+      value,
+      registry => zio.temporal.json.CodecRegistry.autoRegisterActivityImpl[T](registry)
+    )
 
   /** Constructs the wrapper from an ZIO environment */
-  def service[T <: AnyRef: ExtendsActivity: Tag]: URIO[T, ZActivityImplementationObject[T]] =
+  inline def service[T <: AnyRef: ExtendsActivity: Tag]: URIO[T, ZActivityImplementationObject[T]] =
     ZIO.serviceWith[T](ZActivityImplementationObject[T](_))
 
   /** Constructs the wrapper from a ZLayer */
-  def layer[R, E, T <: AnyRef: ExtendsActivity: Tag](
+  inline def layer[R, E, T <: AnyRef: ExtendsActivity: Tag](
     value: ZLayer[R, E, T]
   ): ZLayer[R, E, ZActivityImplementationObject[T]] =
     value >>> ZLayer.fromZIO(service[T])

--- a/core/src/main/scala/zio/temporal/activity/ZActivityImplementationObject.scala
+++ b/core/src/main/scala/zio/temporal/activity/ZActivityImplementationObject.scala
@@ -19,7 +19,7 @@ import zio.temporal.json.CodecRegistry
   *   `ZActivityImplementationObject.apply[T]`.
   */
 final class ZActivityImplementationObject[T <: AnyRef] private[zio] (
-  val value:                          T,
+  val value: T,
   private[zio] val registerCodecs: Option[CodecRegistry] => Unit) {
 
   /** Secondary no-op constructor for binary compatibility with legacy callers that don't build via

--- a/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
+++ b/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
@@ -31,7 +31,7 @@ object InterfaceCodecsMacros {
     val helpers = new InterfaceCodecsHelpers[q.type]
     val codecs  = helpers.collectInterfaceCodecs[I](
       interfaceSym = TypeRepr.of[I].typeSymbol,
-      context = "addInterface"
+      context = "auto-register"
     )
     helpers.foldRegistrations(registry, codecs)
   }

--- a/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
+++ b/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
@@ -38,6 +38,12 @@ object InterfaceCodecsMacros {
   /** Implementation of the auto-registration call site for an interface. Emits
     * `registryOpt.foreach { r => r.register(codec1); r.register(codec2); ... }` at compile time. Opt-out
     * (`codecRegistry = None`) is a silent no-op because the `foreach` body is empty.
+    *
+    * Accepts either a `@workflowInterface`-annotated type (common case) ''or'' a workflow ''implementation'' class
+    * whose supertypes include a `@workflowInterface`. Impl classes show up at
+    * `ZWorker.addWorkflow[Impl].fromClass` call sites — the user's `Impl` satisfies `ExtendsWorkflow` via ancestry
+    * but doesn't carry `@workflowMethod` annotations directly. We walk its base classes for
+    * `@workflowInterface`- or `@activityInterface`-annotated ancestors and register each interface's codecs.
     */
   def autoRegisterInterfaceImpl[I: Type](
     registryOpt: Expr[Option[CodecRegistry]]
@@ -45,11 +51,44 @@ object InterfaceCodecsMacros {
   ): Expr[Unit] = {
     import q.reflect.*
     val helpers = new InterfaceCodecsHelpers[q.type]
-    val codecs  = helpers.collectInterfaceCodecs[I](
-      interfaceSym = TypeRepr.of[I].typeSymbol,
-      context = "auto-register"
-    )
-    helpers.foldForeachRegistrations(registryOpt, codecs)
+
+    val implRepr = TypeRepr.of[I]
+    val implSym  = implRepr.typeSymbol
+
+    val WorkflowInterfaceSym = TypeRepr.of[workflowInterface].typeSymbol
+    val ActivityInterfaceSym = TypeRepr.of[activityInterface].typeSymbol
+
+    // If the type itself is annotated with @workflowInterface / @activityInterface, use it directly.
+    // Otherwise walk ancestors for the closest annotated interface(s). Fall back to `I` itself if neither
+    // the type nor any ancestor is annotated — the collector will then emit a clear error.
+    val interfaceSyms: List[Symbol] = {
+      val selfAnnotated =
+        implSym.hasAnnotation(WorkflowInterfaceSym) || implSym.hasAnnotation(ActivityInterfaceSym)
+
+      if (selfAnnotated) List(implSym)
+      else {
+        val ancestors = implRepr.baseClasses.filter { base =>
+          base != implSym &&
+          (base.hasAnnotation(WorkflowInterfaceSym) || base.hasAnnotation(ActivityInterfaceSym))
+        }.distinct
+        if (ancestors.nonEmpty) ancestors
+        else List(implSym)
+      }
+    }
+
+    val allCodecs = interfaceSyms.flatMap { ifaceSym =>
+      helpers.collectInterfaceCodecs[I](
+        interfaceSym = ifaceSym,
+        context = "auto-register",
+        strict = false
+      )
+    }
+    // Dedupe across interfaces (two ifaces can share a type — e.g. common Input).
+    val deduped = allCodecs.foldLeft(List.empty[helpers.CollectedCodec]) { (acc, c) =>
+      if (acc.exists(_.tpe =:= c.tpe)) acc else acc :+ c
+    }
+
+    helpers.foldForeachRegistrations(registryOpt, deduped)
   }
 
   /** Implementation of the auto-registration call site for an activity ''implementation''. The type parameter `A` is
@@ -71,20 +110,20 @@ object InterfaceCodecsMacros {
 
     // Find every @activityInterface-annotated supertype in A's base classes. If A is itself annotated
     // (rare but possible), we pick A too. Fall back to just A if no annotated ancestor exists — the
-    // compile-time collector will then emit a clear error.
+    // collector will then either find activity methods on A directly or skip silently (in non-strict mode).
     val activityInterfaces: List[Symbol] =
-      implRepr.baseClasses.filter(_.hasAnnotation(ActivityInterfaceSym)) match {
-        case Nil =>
-          // No annotated ancestor. Defer to a plain walk of A itself; the collector will either find
-          // the activity methods (if A has `@activityMethod`s directly) or abort with a clear error.
-          List(implSym)
-        case xs => xs.distinct
-      }
+      if (implSym.hasAnnotation(ActivityInterfaceSym)) List(implSym)
+      else
+        implRepr.baseClasses.filter(_.hasAnnotation(ActivityInterfaceSym)) match {
+          case Nil => List(implSym)
+          case xs  => xs.distinct
+        }
 
     val allCodecs = activityInterfaces.flatMap { ifaceSym =>
       helpers.collectInterfaceCodecs[A](
         interfaceSym = ifaceSym,
-        context = "auto-register activity"
+        context = "auto-register activity",
+        strict = false
       )
     }
     // Dedupe across interfaces (two ifaces can share a type).
@@ -117,8 +156,18 @@ object InterfaceCodecsMacros {
       * collect all boundary-method parameter and return types, summon a `ZTemporalCodec` for each, and return them
       * as a list of (type, codec-expression) pairs. `context` is used in error messages to tell the user which call
       * site triggered the failure.
+      *
+      * When `strict = true` (the default, used by `addInterface[I]`), a missing codec aborts compilation. When
+      * `strict = false` (used by the auto-registration call sites), types without a summonable codec are silently
+      * skipped — auto-reg must not fail compilation for types the user knowingly left uncodec-able (e.g. Scala 3
+      * `Int | Null` erasure-test fixtures, newtype union tests). Those types erase to `Object` at runtime and the
+      * user accepts that the payload path is not meant to handle them.
       */
-    def collectInterfaceCodecs[I: Type](interfaceSym: Symbol, context: String): List[CollectedCodec] = {
+    def collectInterfaceCodecs[I: Type](
+      interfaceSym: Symbol,
+      context:      String,
+      strict:       Boolean = true
+    ): List[CollectedCodec] = {
       val interfaceRepr = TypeRepr.of[I]
       val interfaceName = interfaceSym.fullName
 
@@ -145,11 +194,17 @@ object InterfaceCodecsMacros {
       }.distinct
 
       if (boundaryMethods.isEmpty) {
-        report.errorAndAbort(
-          s"Interface $interfaceName has no methods annotated with @workflowMethod / @signalMethod / " +
-            s"@queryMethod / @activityMethod, and it is not an @activityInterface whose methods are activities by " +
-            s"default. `$context` against `$interfaceName` has nothing to register."
-        )
+        if (strict) {
+          report.errorAndAbort(
+            s"Interface $interfaceName has no methods annotated with @workflowMethod / @signalMethod / " +
+              s"@queryMethod / @activityMethod, and it is not an @activityInterface whose methods are activities by " +
+              s"default. `$context` against `$interfaceName` has nothing to register."
+          )
+        }
+        // Non-strict: silent no-op. This happens when e.g. `ZWorker.addWorkflow[Impl]` falls through to the
+        // impl class itself because no @workflowInterface ancestor was found — the user should have used the
+        // interface type, but that's their bug to fix and not a compile-time show-stopper here.
+        return Nil
       }
 
       // Collect every type that needs a codec: all parameter types + return type.
@@ -222,7 +277,7 @@ object InterfaceCodecsMacros {
 
       // For each type, summon its ZTemporalCodec. The `t.asType match { case '[tpe] => ... }` dance preserves the
       // type parameter so `register[tpe](...)` type-checks downstream.
-      typesNeedingCodecs.map { t =>
+      typesNeedingCodecs.flatMap { t =>
         t.asType match {
           case '[tpe] =>
             val codecType = TypeRepr.of[ZTemporalCodec[tpe]]
@@ -232,14 +287,22 @@ object InterfaceCodecsMacros {
                 // call below recovers the narrow type via the pattern-matched `'[tpe]`. This is safe because the Scala
                 // tree keeps its precise type — the `Any` is just the Scala-level container type.
                 val codecExpr = success.tree.asExprOf[ZTemporalCodec[tpe]].asInstanceOf[Expr[ZTemporalCodec[Any]]]
-                CollectedCodec(t, codecExpr)
+                List(CollectedCodec(t, codecExpr))
               case failure: ImplicitSearchFailure =>
-                report.errorAndAbort(
-                  s"Cannot auto-register codec for type `${t.show}` referenced in interface `$interfaceName`.\n" +
-                    s"Reason: ${failure.explanation}\n" +
-                    "Provide an implicit `ZTemporalCodec` for this type (typically via zio-json `JsonEncoder` + " +
-                    "`JsonDecoder` on its companion), then re-try."
-                )
+                if (strict) {
+                  report.errorAndAbort(
+                    s"Cannot $context codec for type `${t.show}` referenced in interface `$interfaceName`.\n" +
+                      s"Reason: ${failure.explanation}\n" +
+                      "Provide an implicit `ZTemporalCodec` for this type (typically via zio-json `JsonEncoder` + " +
+                      "`JsonDecoder` on its companion), then re-try."
+                  )
+                } else {
+                  // Non-strict: silently skip. The user either registered the codec elsewhere (explicit
+                  // `.addInterface` / `.register`) or accepts that this type is uncodec-able (e.g. Scala 3 union
+                  // types that erase to Object). A runtime "No ZTemporalCodec registered for …" will still fire
+                  // at encode time if they actually try to serialize a value of the missing type.
+                  Nil
+                }
             }
         }
       }

--- a/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
+++ b/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
@@ -15,152 +15,279 @@ import scala.quoted.*
   * The summoned codecs are emitted as runtime registrations into the supplied [[CodecRegistry]]. This is what makes
   * `CodecRegistry#addInterface[I]` work end-to-end: compile-time evidence of codec existence + runtime registration in
   * one call.
+  *
+  * The same machinery is used by the ''auto-registration'' path (`autoRegisterInterfaceImpl`,
+  * `autoRegisterActivityImplImpl`), which is invoked from `ZWorker.addWorkflow[I]`, `ZWorker.addActivityImplementation`,
+  * `ZWorkflowClient.newWorkflowStub[A]`, etc. to remove the need for users to call `.addInterface[...]` by hand.
   */
 object InterfaceCodecsMacros {
 
   /** Implementation of `CodecRegistry#addInterface[I]`. Walks `I`, summons codecs, emits a chained
-    * `registry.register(...)` for each.
+    * `registry.register(...)` for each, and returns the (same) registry expression.
     */
   def addInterfaceImpl[I: Type](registry: Expr[CodecRegistry])(using q: Quotes): Expr[CodecRegistry] = {
     import q.reflect.*
+    val helpers = new InterfaceCodecsHelpers[q.type]
+    val codecs  = helpers.collectInterfaceCodecs[I](
+      interfaceSym = TypeRepr.of[I].typeSymbol,
+      context = "addInterface"
+    )
+    helpers.foldRegistrations(registry, codecs)
+  }
 
-    val interfaceRepr = TypeRepr.of[I]
-    val interfaceSym  = interfaceRepr.typeSymbol
-    val interfaceName = interfaceRepr.show
+  /** Implementation of the auto-registration call site for an interface. Emits
+    * `registryOpt.foreach { r => r.register(codec1); r.register(codec2); ... }` at compile time. Opt-out
+    * (`codecRegistry = None`) is a silent no-op because the `foreach` body is empty.
+    */
+  def autoRegisterInterfaceImpl[I: Type](
+    registryOpt: Expr[Option[CodecRegistry]]
+  )(using q:     Quotes
+  ): Expr[Unit] = {
+    import q.reflect.*
+    val helpers = new InterfaceCodecsHelpers[q.type]
+    val codecs  = helpers.collectInterfaceCodecs[I](
+      interfaceSym = TypeRepr.of[I].typeSymbol,
+      context = "auto-register"
+    )
+    helpers.foldForeachRegistrations(registryOpt, codecs)
+  }
 
-    val WorkflowMethodSym    = TypeRepr.of[workflowMethod].typeSymbol
-    val SignalMethodSym      = TypeRepr.of[signalMethod].typeSymbol
-    val QueryMethodSym       = TypeRepr.of[queryMethod].typeSymbol
-    val ActivityMethodSym    = TypeRepr.of[activityMethod].typeSymbol
+  /** Implementation of the auto-registration call site for an activity ''implementation''. The type parameter `A` is
+    * the concrete implementation class (e.g. `MyActivityImpl`) — we walk its supertype chain for
+    * `@activityInterface`-annotated interfaces and register each one's codecs.
+    *
+    * Users occasionally declare one impl that implements two activity interfaces; each is walked.
+    */
+  def autoRegisterActivityImplImpl[A: Type](
+    registryOpt: Expr[Option[CodecRegistry]]
+  )(using q:     Quotes
+  ): Expr[Unit] = {
+    import q.reflect.*
+    val helpers = new InterfaceCodecsHelpers[q.type]
+
+    val implRepr = TypeRepr.of[A]
+    val implSym  = implRepr.typeSymbol
     val ActivityInterfaceSym = TypeRepr.of[activityInterface].typeSymbol
-    val WorkflowInterfaceSym = TypeRepr.of[workflowInterface].typeSymbol
 
-    val boundaryAnnotations = List(WorkflowMethodSym, SignalMethodSym, QueryMethodSym, ActivityMethodSym)
-
-    // On an @activityInterface, every public method is an activity (Java SDK convention). On a @workflowInterface,
-    // only methods carrying a @workflowMethod/@signalMethod/@queryMethod annotation qualify.
-    val isActivityInterface =
-      interfaceSym.hasAnnotation(ActivityInterfaceSym) ||
-        interfaceRepr.baseClasses.exists(_.hasAnnotation(ActivityInterfaceSym))
-
-    // Consider inherited methods too: a sealed workflow like `SodaWorkflow extends ParameterizedWorkflow[Input]` has
-    // its @workflowMethod inherited from the parent.
-    val allMethods = interfaceSym.methodMembers ++ interfaceSym.declaredMethods
-
-    val boundaryMethods = allMethods.filter { m =>
-      if (isActivityInterface) {
-        // Skip inherited Object methods — `toString`, `equals`, `hashCode`, etc. aren't activity endpoints.
-        m.flags.is(Flags.Method) &&
-        !m.flags.is(Flags.Synthetic) &&
-        m.owner != defn.AnyClass &&
-        m.owner != defn.ObjectClass
-      } else {
-        boundaryAnnotations.exists(m.hasAnnotation)
+    // Find every @activityInterface-annotated supertype in A's base classes. If A is itself annotated
+    // (rare but possible), we pick A too. Fall back to just A if no annotated ancestor exists — the
+    // compile-time collector will then emit a clear error.
+    val activityInterfaces: List[Symbol] =
+      implRepr.baseClasses.filter(_.hasAnnotation(ActivityInterfaceSym)) match {
+        case Nil =>
+          // No annotated ancestor. Defer to a plain walk of A itself; the collector will either find
+          // the activity methods (if A has `@activityMethod`s directly) or abort with a clear error.
+          List(implSym)
+        case xs => xs.distinct
       }
-    }.distinct
 
-    if (boundaryMethods.isEmpty) {
-      report.errorAndAbort(
-        s"Interface $interfaceName has no methods annotated with @workflowMethod / @signalMethod / " +
-          s"@queryMethod / @activityMethod, and it is not an @activityInterface whose methods are activities by " +
-          s"default. `addInterface[$interfaceName]` has nothing to register."
+    val allCodecs = activityInterfaces.flatMap { ifaceSym =>
+      helpers.collectInterfaceCodecs[A](
+        interfaceSym = ifaceSym,
+        context = "auto-register activity"
       )
     }
-
-    // Collect every type that needs a codec: all parameter types + return type.
-    // Use `interfaceRepr.memberType(m)` to resolve type parameters in the subclass's view — this makes a method
-    // inherited from `Parent[User]` expose `User` as the parameter type rather than the abstract `A`.
-    def collect(tpe: TypeRepr): List[TypeRepr] =
-      tpe match {
-        case MethodType(_, paramTypes, resultType) =>
-          paramTypes ++ collect(resultType)
-        case PolyType(_, _, resultType) =>
-          collect(resultType)
-        case ByNameType(underlying) =>
-          collect(underlying)
-        case other =>
-          List(other)
-      }
-
-    // Also collect the type arguments of parameterized types — recursively. Every `List[Foo]` needs `Foo` registered
-    // separately too, because the runtime encode path dispatches per-element using the element's own runtime class
-    // (see `ZioJsonPayloadConverter#encodeContainer`). Without this recursion, a `List[Foo]` would have its own
-    // parameterized-type codec in `byType` but no encoder for `Foo` in `byClass`, and per-element dispatch would
-    // fall through to "not registered."
-    def expandTypeArgs(tpe: TypeRepr): List[TypeRepr] = {
-      val direct = tpe match {
-        case AppliedType(_, args) => args.flatMap(expandTypeArgs)
-        case _                    => Nil
-      }
-      tpe +: direct
+    // Dedupe across interfaces (two ifaces can share a type).
+    val deduped = allCodecs.foldLeft(List.empty[helpers.CollectedCodec]) { (acc, c) =>
+      if (acc.exists(_.tpe =:= c.tpe)) acc else acc :+ c
     }
 
-    // Redirect a concrete sealed subtype to its sealed ancestor so the registry only ever holds the parent codec
-    // for types in a sealed hierarchy. Encoder lookup on a runtime class of `Soda` walks its supertype chain and
-    // lands on the parent codec; decoder lookup on the inherited-method's upper-bound also lands on the parent
-    // codec. Both sides converge on the same wrapped JSON shape (e.g. `{"Soda":{...}}`) — otherwise a directly
-    // registered `Soda` codec would emit a flat `{"kind":"cola"}` that the parent-registered decoder rejects.
-    //
-    // Walk the candidate chain nearest-first and promote to the first ancestor that actually has a summonable
-    // `ZTemporalCodec`. This matters for scalapb-generated sealed-oneof messages: a `ChildWorkflowInput.Soda`
-    // has `NonEmpty` as its nearest sealed ancestor (a scalapb-internal marker with no codec) and
-    // `ChildWorkflowInput` one level further up (which does have a codec via `scalapbSealedOneofZTemporalCodec`).
-    // Picking the first promoting ancestor with a codec lets that case compile while keeping the common
-    // "user sealed trait + derived JsonCodec" case unchanged. Fall back to the original type if no ancestor has
-    // a codec — the outer summon either succeeds (the subtype itself has a codec) or fails in the normal path.
-    //
-    // Standard-library sealed traits (e.g. `scala.deriving.Mirror`, which is an ancestor of every case object's
-    // mirror) are intentionally excluded — they are internal markers, not serialization targets.
-    def promoteToSealedParent(tpe: TypeRepr): TypeRepr = {
-      val selfSym    = tpe.typeSymbol
-      val candidates = tpe.baseClasses.filter { base =>
-        base != selfSym &&
-        base.flags.is(Flags.Sealed) &&
-        (base.flags.is(Flags.Trait) || base.flags.is(Flags.Abstract)) &&
-        base != defn.AnyClass &&
-        base != defn.ObjectClass &&
-        base != defn.AnyValClass &&
-        !isStdlibSymbol(base)
+    helpers.foldForeachRegistrations(registryOpt, deduped)
+  }
+
+  /** Class-scoped helpers used by the macro entry points. Holding them in a class parameterized on `Q <: Quotes` keeps
+    * the `q.reflect.*` path-dependent types consistent across helper methods.
+    */
+  private class InterfaceCodecsHelpers[Q <: Quotes](using val q: Q) {
+    import q.reflect.*
+
+    /** A single codec to register: the Scala type and the summoned `ZTemporalCodec` expression. */
+    case class CollectedCodec(tpe: TypeRepr, codecExpr: Expr[ZTemporalCodec[Any]])
+
+    private val WorkflowMethodSym    = TypeRepr.of[workflowMethod].typeSymbol
+    private val SignalMethodSym      = TypeRepr.of[signalMethod].typeSymbol
+    private val QueryMethodSym       = TypeRepr.of[queryMethod].typeSymbol
+    private val ActivityMethodSym    = TypeRepr.of[activityMethod].typeSymbol
+    private val ActivityInterfaceSym = TypeRepr.of[activityInterface].typeSymbol
+    private val WorkflowInterfaceSym = TypeRepr.of[workflowInterface].typeSymbol
+
+    private val boundaryAnnotations = List(WorkflowMethodSym, SignalMethodSym, QueryMethodSym, ActivityMethodSym)
+
+    /** Walk the interface `I` (or the symbol identified by `interfaceSym`, which must be compatible with `I`),
+      * collect all boundary-method parameter and return types, summon a `ZTemporalCodec` for each, and return them
+      * as a list of (type, codec-expression) pairs. `context` is used in error messages to tell the user which call
+      * site triggered the failure.
+      */
+    def collectInterfaceCodecs[I: Type](interfaceSym: Symbol, context: String): List[CollectedCodec] = {
+      val interfaceRepr = TypeRepr.of[I]
+      val interfaceName = interfaceSym.fullName
+
+      // On an @activityInterface, every public method is an activity (Java SDK convention). On a @workflowInterface,
+      // only methods carrying a @workflowMethod/@signalMethod/@queryMethod annotation qualify.
+      val isActivityInterface =
+        interfaceSym.hasAnnotation(ActivityInterfaceSym) ||
+          interfaceSym.typeRef.baseClasses.exists(_.hasAnnotation(ActivityInterfaceSym))
+
+      // Consider inherited methods too: a sealed workflow like `SodaWorkflow extends ParameterizedWorkflow[Input]` has
+      // its @workflowMethod inherited from the parent.
+      val allMethods = interfaceSym.methodMembers ++ interfaceSym.declaredMethods
+
+      val boundaryMethods = allMethods.filter { m =>
+        if (isActivityInterface) {
+          // Skip inherited Object methods — `toString`, `equals`, `hashCode`, etc. aren't activity endpoints.
+          m.flags.is(Flags.Method) &&
+          !m.flags.is(Flags.Synthetic) &&
+          m.owner != defn.AnyClass &&
+          m.owner != defn.ObjectClass
+        } else {
+          boundaryAnnotations.exists(m.hasAnnotation)
+        }
+      }.distinct
+
+      if (boundaryMethods.isEmpty) {
+        report.errorAndAbort(
+          s"Interface $interfaceName has no methods annotated with @workflowMethod / @signalMethod / " +
+            s"@queryMethod / @activityMethod, and it is not an @activityInterface whose methods are activities by " +
+            s"default. `$context` against `$interfaceName` has nothing to register."
+        )
       }
-      candidates.headOption match {
-        case Some(parent) => tpe.baseType(parent)
-        case None         => tpe
+
+      // Collect every type that needs a codec: all parameter types + return type.
+      // Use `interfaceRepr.memberType(m)` to resolve type parameters in the subclass's view — this makes a method
+      // inherited from `Parent[User]` expose `User` as the parameter type rather than the abstract `A`.
+      def collect(tpe: TypeRepr): List[TypeRepr] =
+        tpe match {
+          case MethodType(_, paramTypes, resultType) =>
+            paramTypes ++ collect(resultType)
+          case PolyType(_, _, resultType) =>
+            collect(resultType)
+          case ByNameType(underlying) =>
+            collect(underlying)
+          case other =>
+            List(other)
+        }
+
+      // Also collect the type arguments of parameterized types — recursively. Every `List[Foo]` needs `Foo` registered
+      // separately too, because the runtime encode path dispatches per-element using the element's own runtime class
+      // (see `ZioJsonPayloadConverter#encodeContainer`). Without this recursion, a `List[Foo]` would have its own
+      // parameterized-type codec in `byType` but no encoder for `Foo` in `byClass`, and per-element dispatch would
+      // fall through to "not registered."
+      def expandTypeArgs(tpe: TypeRepr): List[TypeRepr] = {
+        val direct = tpe match {
+          case AppliedType(_, args) => args.flatMap(expandTypeArgs)
+          case _                    => Nil
+        }
+        tpe +: direct
+      }
+
+      // Redirect a concrete sealed subtype to its sealed ancestor so the registry only ever holds the parent codec
+      // for types in a sealed hierarchy. Encoder lookup on a runtime class of `Soda` walks its supertype chain and
+      // lands on the parent codec; decoder lookup on the inherited-method's upper-bound also lands on the parent
+      // codec. Both sides converge on the same wrapped JSON shape (e.g. `{"Soda":{...}}`) — otherwise a directly
+      // registered `Soda` codec would emit a flat `{"kind":"cola"}` that the parent-registered decoder rejects.
+      //
+      // Standard-library sealed traits (e.g. `scala.deriving.Mirror`, which is an ancestor of every case object's
+      // mirror) are intentionally excluded — they are internal markers, not serialization targets.
+      def promoteToSealedParent(tpe: TypeRepr): TypeRepr = {
+        val selfSym    = tpe.typeSymbol
+        val candidates = tpe.baseClasses.filter { base =>
+          base != selfSym &&
+          base.flags.is(Flags.Sealed) &&
+          (base.flags.is(Flags.Trait) || base.flags.is(Flags.Abstract)) &&
+          base != defn.AnyClass &&
+          base != defn.ObjectClass &&
+          base != defn.AnyValClass &&
+          !isStdlibSymbol(base)
+        }
+        candidates.headOption match {
+          case Some(parent) => tpe.baseType(parent)
+          case None         => tpe
+        }
+      }
+
+      def isStdlibSymbol(sym: Symbol): Boolean = {
+        val name = sym.fullName
+        name.startsWith("scala.") || name.startsWith("java.") || name.startsWith("javax.")
+      }
+
+      val typesNeedingCodecs: List[TypeRepr] = boundaryMethods
+        .flatMap { m =>
+          val resolved = interfaceRepr.memberType(m)
+          collect(resolved).flatMap(expandTypeArgs).map(promoteToSealedParent)
+        }
+        .foldLeft(List.empty[TypeRepr]) { (acc, t) =>
+          // Dedupe by semantic equivalence — avoids emitting duplicate register() calls.
+          if (acc.exists(_ =:= t)) acc else acc :+ t
+        }
+
+      // For each type, summon its ZTemporalCodec. The `t.asType match { case '[tpe] => ... }` dance preserves the
+      // type parameter so `register[tpe](...)` type-checks downstream.
+      typesNeedingCodecs.map { t =>
+        t.asType match {
+          case '[tpe] =>
+            val codecType = TypeRepr.of[ZTemporalCodec[tpe]]
+            Implicits.search(codecType) match {
+              case success: ImplicitSearchSuccess =>
+                // Cast the encoded tree to ZTemporalCodec[Any] for the heterogeneous list; the actual `register[tpe]`
+                // call below recovers the narrow type via the pattern-matched `'[tpe]`. This is safe because the Scala
+                // tree keeps its precise type — the `Any` is just the Scala-level container type.
+                val codecExpr = success.tree.asExprOf[ZTemporalCodec[tpe]].asInstanceOf[Expr[ZTemporalCodec[Any]]]
+                CollectedCodec(t, codecExpr)
+              case failure: ImplicitSearchFailure =>
+                report.errorAndAbort(
+                  s"Cannot auto-register codec for type `${t.show}` referenced in interface `$interfaceName`.\n" +
+                    s"Reason: ${failure.explanation}\n" +
+                    "Provide an implicit `ZTemporalCodec` for this type (typically via zio-json `JsonEncoder` + " +
+                    "`JsonDecoder` on its companion), then re-try."
+                )
+            }
+        }
       }
     }
 
-    def isStdlibSymbol(sym: Symbol): Boolean = {
-      val name = sym.fullName
-      name.startsWith("scala.") || name.startsWith("java.") || name.startsWith("javax.")
+    /** Fold each collected codec into a chained `registry.register(...)` expression, returning the final registry
+      * expression. Used by `addInterface[I]` which returns `CodecRegistry` for fluent chaining.
+      */
+    def foldRegistrations(
+      registry: Expr[CodecRegistry],
+      codecs:   List[CollectedCodec]
+    ): Expr[CodecRegistry] = {
+      codecs.foldLeft(registry) { (acc, collected) =>
+        collected.tpe.asType match {
+          case '[tpe] =>
+            val narrowed = collected.codecExpr.asExprOf[ZTemporalCodec[tpe]]
+            '{ $acc.register[tpe]($narrowed) }
+        }
+      }
     }
 
-    val typesNeedingCodecs: List[TypeRepr] = boundaryMethods
-      .flatMap { m =>
-        val resolved = interfaceRepr.memberType(m)
-        collect(resolved).flatMap(expandTypeArgs).map(promoteToSealedParent)
-      }
-      .foldLeft(List.empty[TypeRepr]) { (acc, t) =>
-        // Dedupe by semantic equivalence — avoids emitting duplicate register() calls.
-        if (acc.exists(_ =:= t)) acc else acc :+ t
-      }
-
-    // For each type, summon its ZTemporalCodec and fold a register() call onto the accumulating registry expression.
-    // The `t.asType match { case '[tpe] => ... }` dance preserves the type parameter so `register[tpe](...)` type-checks.
-    typesNeedingCodecs.foldLeft(registry) { (acc, t) =>
-      t.asType match {
-        case '[tpe] =>
-          val codecType = TypeRepr.of[ZTemporalCodec[tpe]]
-          Implicits.search(codecType) match {
-            case success: ImplicitSearchSuccess =>
-              val codecExpr = success.tree.asExprOf[ZTemporalCodec[tpe]]
-              '{ $acc.register[tpe]($codecExpr) }
-            case failure: ImplicitSearchFailure =>
-              report.errorAndAbort(
-                s"Cannot auto-register codec for type `${t.show}` referenced in interface `$interfaceName`.\n" +
-                  s"Reason: ${failure.explanation}\n" +
-                  "Provide an implicit `ZTemporalCodec` for this type (typically via zio-json `JsonEncoder` + " +
-                  "`JsonDecoder` on its companion), then re-try `addInterface`."
-              )
+    /** Emit `registryOpt.foreach { r => r.register(c1); r.register(c2); ... }`. When `registryOpt` is `None` at
+      * runtime, the `foreach` body never executes — that's the opt-out path for users who supplied their own
+      * `DataConverter`.
+      */
+    def foldForeachRegistrations(
+      registryOpt: Expr[Option[CodecRegistry]],
+      codecs:      List[CollectedCodec]
+    ): Expr[Unit] = {
+      if (codecs.isEmpty) {
+        '{ () }
+      } else {
+        '{
+          $registryOpt.foreach { r =>
+            ${
+              // Build a block of r.register(...) statements inside the foreach.
+              val stmts: List[Expr[Any]] = codecs.map { collected =>
+                collected.tpe.asType match {
+                  case '[tpe] =>
+                    val narrowed = collected.codecExpr.asExprOf[ZTemporalCodec[tpe]]
+                    '{ r.register[tpe]($narrowed) }
+                }
+              }
+              Expr.block(stmts.init, stmts.last.asExprOf[Any])
+            }
+            ()
           }
+        }
       }
     }
   }

--- a/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
+++ b/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
@@ -17,8 +17,9 @@ import scala.quoted.*
   * one call.
   *
   * The same machinery is used by the ''auto-registration'' path (`autoRegisterInterfaceImpl`,
-  * `autoRegisterActivityImplImpl`), which is invoked from `ZWorker.addWorkflow[I]`, `ZWorker.addActivityImplementation`,
-  * `ZWorkflowClient.newWorkflowStub[A]`, etc. to remove the need for users to call `.addInterface[...]` by hand.
+  * `autoRegisterActivityImplImpl`), which is invoked from `ZWorker.addWorkflow[I]`,
+  * `ZWorker.addActivityImplementation`, `ZWorkflowClient.newWorkflowStub[A]`, etc. to remove the need for users to call
+  * `.addInterface[...]` by hand.
   */
 object InterfaceCodecsMacros {
 
@@ -40,10 +41,10 @@ object InterfaceCodecsMacros {
     * (`codecRegistry = None`) is a silent no-op because the `foreach` body is empty.
     *
     * Accepts either a `@workflowInterface`-annotated type (common case) ''or'' a workflow ''implementation'' class
-    * whose supertypes include a `@workflowInterface`. Impl classes show up at
-    * `ZWorker.addWorkflow[Impl].fromClass` call sites — the user's `Impl` satisfies `ExtendsWorkflow` via ancestry
-    * but doesn't carry `@workflowMethod` annotations directly. We walk its base classes for
-    * `@workflowInterface`- or `@activityInterface`-annotated ancestors and register each interface's codecs.
+    * whose supertypes include a `@workflowInterface`. Impl classes show up at `ZWorker.addWorkflow[Impl].fromClass`
+    * call sites — the user's `Impl` satisfies `ExtendsWorkflow` via ancestry but doesn't carry `@workflowMethod`
+    * annotations directly. We walk its base classes for `@workflowInterface`- or `@activityInterface`-annotated
+    * ancestors and register each interface's codecs.
     */
   def autoRegisterInterfaceImpl[I: Type](
     registryOpt: Expr[Option[CodecRegistry]]
@@ -104,8 +105,8 @@ object InterfaceCodecsMacros {
     import q.reflect.*
     val helpers = new InterfaceCodecsHelpers[q.type]
 
-    val implRepr = TypeRepr.of[A]
-    val implSym  = implRepr.typeSymbol
+    val implRepr             = TypeRepr.of[A]
+    val implSym              = implRepr.typeSymbol
     val ActivityInterfaceSym = TypeRepr.of[activityInterface].typeSymbol
 
     // Find every @activityInterface-annotated supertype in A's base classes. If A is itself annotated
@@ -152,16 +153,16 @@ object InterfaceCodecsMacros {
 
     private val boundaryAnnotations = List(WorkflowMethodSym, SignalMethodSym, QueryMethodSym, ActivityMethodSym)
 
-    /** Walk the interface `I` (or the symbol identified by `interfaceSym`, which must be compatible with `I`),
-      * collect all boundary-method parameter and return types, summon a `ZTemporalCodec` for each, and return them
-      * as a list of (type, codec-expression) pairs. `context` is used in error messages to tell the user which call
-      * site triggered the failure.
+    /** Walk the interface `I` (or the symbol identified by `interfaceSym`, which must be compatible with `I`), collect
+      * all boundary-method parameter and return types, summon a `ZTemporalCodec` for each, and return them as a list of
+      * (type, codec-expression) pairs. `context` is used in error messages to tell the user which call site triggered
+      * the failure.
       *
       * When `strict = true` (the default, used by `addInterface[I]`), a missing codec aborts compilation. When
       * `strict = false` (used by the auto-registration call sites), types without a summonable codec are silently
       * skipped — auto-reg must not fail compilation for types the user knowingly left uncodec-able (e.g. Scala 3
-      * `Int | Null` erasure-test fixtures, newtype union tests). Those types erase to `Object` at runtime and the
-      * user accepts that the payload path is not meant to handle them.
+      * `Int | Null` erasure-test fixtures, newtype union tests). Those types erase to `Object` at runtime and the user
+      * accepts that the payload path is not meant to handle them.
       */
     def collectInterfaceCodecs[I: Type](
       interfaceSym: Symbol,

--- a/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
+++ b/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
@@ -160,10 +160,11 @@ object InterfaceCodecsMacros {
       * the failure.
       *
       * When `strict = true` (the default, used by `addInterface[I]`), a missing codec aborts compilation. When
-      * `strict = false` (used by the auto-registration call sites), types without a summonable codec are silently
-      * skipped — auto-reg must not fail compilation for types the user knowingly left uncodec-able (e.g. Scala 3
-      * `Int | Null` erasure-test fixtures, newtype union tests). Those types erase to `Object` at runtime and the user
-      * accepts that the payload path is not meant to handle them.
+      * `strict = false` (used by the auto-registration call sites), types without a summonable codec are skipped with a
+      * compile-time warning rather than an error — auto-reg must not fail compilation for types the user knowingly left
+      * uncodec-able (e.g. Scala 3 `Int | Null` erasure-test fixtures, newtype union tests), which erase to `Object` at
+      * runtime and are handled by a separate fallback. The warning still surfaces the skip so a genuinely forgotten
+      * codec isn't silent.
       */
     def collectInterfaceCodecs[I: Type](
       interfaceSym: Symbol,
@@ -299,10 +300,20 @@ object InterfaceCodecsMacros {
                       "`JsonDecoder` on its companion), then re-try."
                   )
                 } else {
-                  // Non-strict: silently skip. The user either registered the codec elsewhere (explicit
-                  // `.addInterface` / `.register`) or accepts that this type is uncodec-able (e.g. Scala 3 union
-                  // types that erase to Object). A runtime "No ZTemporalCodec registered for …" will still fire
-                  // at encode time if they actually try to serialize a value of the missing type.
+                  // Non-strict: skip, but warn — don't fail the build. Some referenced types genuinely have no
+                  // registrable codec by design (e.g. Scala 3 union types that erase to Object, handled by a
+                  // separate runtime fallback in ZioJsonPayloadConverter). But most of the time a skip here means
+                  // the user forgot a codec, and letting that pass in total silence reintroduces exactly the
+                  // "silent hang until first execute()" failure mode the compile-time gate exists to prevent.
+                  // The warning surfaces it at compile time without hard-failing the cases that need to stay green.
+                  report.warning(
+                    s"Cannot $context codec for type `${t.show}` referenced in interface `$interfaceName` — " +
+                      "skipping (auto-registration is non-strict).\n" +
+                      s"Reason: ${failure.explanation}\n" +
+                      "If this type is actually serialized, this will fail at runtime with " +
+                      "`No ZTemporalCodec registered for …`. Provide an implicit `ZTemporalCodec` for this type, " +
+                      "or if this is intentional (e.g. an erased union type with a runtime fallback), ignore this warning."
+                  )
                   Nil
                 }
             }

--- a/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
+++ b/core/src/main/scala/zio/temporal/internal/InterfaceCodecsMacros.scala
@@ -61,7 +61,8 @@ object InterfaceCodecsMacros {
 
     // If the type itself is annotated with @workflowInterface / @activityInterface, use it directly.
     // Otherwise walk ancestors for the closest annotated interface(s). Fall back to `I` itself if neither
-    // the type nor any ancestor is annotated — the collector will then emit a clear error.
+    // the type nor any ancestor is annotated; in this auto-registration path we collect with `strict = false`,
+    // so a type with no annotated boundary methods simply contributes no codecs.
     val interfaceSyms: List[Symbol] = {
       val selfAnnotated =
         implSym.hasAnnotation(WorkflowInterfaceSym) || implSym.hasAnnotation(ActivityInterfaceSym)

--- a/core/src/main/scala/zio/temporal/json/CodecRegistry.scala
+++ b/core/src/main/scala/zio/temporal/json/CodecRegistry.scala
@@ -278,6 +278,28 @@ object CodecRegistry {
   /** One registered parameterized-type codec candidate. Held per raw class in `byRawClass`. */
   private[json] final case class ParamEntry(genericType: Type, encoder: JsonEncoder[_], decoder: JsonDecoder[_])
 
+  /** Auto-registration entry point for an interface. Walks `I`'s `@workflowMethod` / `@signalMethod` /
+    * `@queryMethod` / `@activityMethod` methods and, if `registryOpt` is `Some(r)`, registers every
+    * parameter and return type's codec into `r`. When `registryOpt` is `None` this is a silent no-op —
+    * that's how the opt-out path for `withDataConverter(raw)` works.
+    *
+    * Used by `ZWorker.addWorkflow[I]`, `ZWorkflowClient.newWorkflowStub[I]`, and friends to eliminate the
+    * manual `.addInterface[...]` boilerplate. Users who want explicit control still have
+    * [[CodecRegistry#addInterface]].
+    */
+  inline def autoRegisterInterface[I](registryOpt: Option[CodecRegistry]): Unit =
+    ${ zio.temporal.internal.InterfaceCodecsMacros.autoRegisterInterfaceImpl[I]('registryOpt) }
+
+  /** Auto-registration entry point for an activity ''implementation class''. The type parameter `A` is the
+    * concrete impl type (e.g. `MyActivityImpl`); the macro walks `A`'s base classes, finds every
+    * `@activityInterface`-annotated ancestor, and registers each interface's codecs into the registry.
+    *
+    * This is the path taken by `ZWorker.addActivityImplementation(activity)` / friends, where the user
+    * passes an implementation whose declared type doesn't identify the activity interface directly.
+    */
+  inline def autoRegisterActivityImpl[A](registryOpt: Option[CodecRegistry]): Unit =
+    ${ zio.temporal.internal.InterfaceCodecsMacros.autoRegisterActivityImplImpl[A]('registryOpt) }
+
   /** Build a registry pre-populated with the given codecs. The typical usage from a client or worker setup:
     *
     * {{{

--- a/core/src/main/scala/zio/temporal/json/CodecRegistry.scala
+++ b/core/src/main/scala/zio/temporal/json/CodecRegistry.scala
@@ -278,24 +278,23 @@ object CodecRegistry {
   /** One registered parameterized-type codec candidate. Held per raw class in `byRawClass`. */
   private[json] final case class ParamEntry(genericType: Type, encoder: JsonEncoder[_], decoder: JsonDecoder[_])
 
-  /** Auto-registration entry point for an interface. Walks `I`'s `@workflowMethod` / `@signalMethod` /
-    * `@queryMethod` / `@activityMethod` methods and, if `registryOpt` is `Some(r)`, registers every
-    * parameter and return type's codec into `r`. When `registryOpt` is `None` this is a silent no-op —
-    * that's how the opt-out path for `withDataConverter(raw)` works.
+  /** Auto-registration entry point for an interface. Walks `I`'s `@workflowMethod` / `@signalMethod` / `@queryMethod` /
+    * `@activityMethod` methods and, if `registryOpt` is `Some(r)`, registers every parameter and return type's codec
+    * into `r`. When `registryOpt` is `None` this is a silent no-op — that's how the opt-out path for
+    * `withDataConverter(raw)` works.
     *
-    * Used by `ZWorker.addWorkflow[I]`, `ZWorkflowClient.newWorkflowStub[I]`, and friends to eliminate the
-    * manual `.addInterface[...]` boilerplate. Users who want explicit control still have
-    * [[CodecRegistry#addInterface]].
+    * Used by `ZWorker.addWorkflow[I]`, `ZWorkflowClient.newWorkflowStub[I]`, and friends to eliminate the manual
+    * `.addInterface[...]` boilerplate. Users who want explicit control still have [[CodecRegistry#addInterface]].
     */
   inline def autoRegisterInterface[I](registryOpt: Option[CodecRegistry]): Unit =
     ${ zio.temporal.internal.InterfaceCodecsMacros.autoRegisterInterfaceImpl[I]('registryOpt) }
 
-  /** Auto-registration entry point for an activity ''implementation class''. The type parameter `A` is the
-    * concrete impl type (e.g. `MyActivityImpl`); the macro walks `A`'s base classes, finds every
-    * `@activityInterface`-annotated ancestor, and registers each interface's codecs into the registry.
+  /** Auto-registration entry point for an activity ''implementation class''. The type parameter `A` is the concrete
+    * impl type (e.g. `MyActivityImpl`); the macro walks `A`'s base classes, finds every `@activityInterface`-annotated
+    * ancestor, and registers each interface's codecs into the registry.
     *
-    * This is the path taken by `ZWorker.addActivityImplementation(activity)` / friends, where the user
-    * passes an implementation whose declared type doesn't identify the activity interface directly.
+    * This is the path taken by `ZWorker.addActivityImplementation(activity)` / friends, where the user passes an
+    * implementation whose declared type doesn't identify the activity interface directly.
     */
   inline def autoRegisterActivityImpl[A](registryOpt: Option[CodecRegistry]): Unit =
     ${ zio.temporal.internal.InterfaceCodecsMacros.autoRegisterActivityImplImpl[A]('registryOpt) }

--- a/core/src/main/scala/zio/temporal/worker/ZWorker.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorker.scala
@@ -4,6 +4,7 @@ import zio._
 import zio.temporal.internal.ClassTagUtils
 import io.temporal.worker.Worker
 import zio.temporal.activity.{ExtendsActivity, IsActivity, ZActivityImplementationObject}
+import zio.temporal.json.CodecRegistry
 import zio.temporal.workflow.{
   ExtendsWorkflow,
   HasPublicNullaryConstructor,
@@ -17,9 +18,19 @@ import scala.reflect.ClassTag
 
 /** Hosts activity and workflow implementations. Uses long poll to receive activity and workflow tasks and processes
   * them in a correspondent thread pool.
+  *
+  * The `codecRegistry` carried here is the ''same'' `CodecRegistry` owned by this worker's
+  * `ZWorkflowClientOptions`. When `None`, the user supplied a custom `DataConverter` via `withDataConverter(raw)`
+  * and auto-registration is a silent no-op. When `Some`, the auto-registration call sites (`addWorkflow[I]` /
+  * `addActivityImplementation(impl)` / …) populate the registry at invocation time so users don't need to chain
+  * `.addInterface[...]` by hand on the options.
   */
 class ZWorker private[zio] (
-  val toJava: Worker) {
+  val toJava:                     Worker,
+  private[zio] val codecRegistry: Option[CodecRegistry]) {
+
+  /** Secondary constructor retained for call sites that don't have a registry reference. */
+  private[zio] def this(toJava: Worker) = this(toJava, None)
 
   def taskQueue: String =
     toJava.getTaskQueue

--- a/core/src/main/scala/zio/temporal/worker/ZWorker.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorker.scala
@@ -19,14 +19,14 @@ import scala.reflect.ClassTag
 /** Hosts activity and workflow implementations. Uses long poll to receive activity and workflow tasks and processes
   * them in a correspondent thread pool.
   *
-  * The `codecRegistry` carried here is the ''same'' `CodecRegistry` owned by this worker's
-  * `ZWorkflowClientOptions`. When `None`, the user supplied a custom `DataConverter` via `withDataConverter(raw)`
-  * and auto-registration is a silent no-op. When `Some`, the auto-registration call sites (`addWorkflow[I]` /
-  * `addActivityImplementation(impl)` / …) populate the registry at invocation time so users don't need to chain
-  * `.addInterface[...]` by hand on the options.
+  * The `codecRegistry` carried here is the ''same'' `CodecRegistry` owned by this worker's `ZWorkflowClientOptions`.
+  * When `None`, the user supplied a custom `DataConverter` via `withDataConverter(raw)` and auto-registration is a
+  * silent no-op. When `Some`, the auto-registration call sites (`addWorkflow[I]` / `addActivityImplementation(impl)` /
+  * …) populate the registry at invocation time so users don't need to chain `.addInterface[...]` by hand on the
+  * options.
   */
 class ZWorker private[zio] (
-  val toJava:                     Worker,
+  val toJava: Worker,
   private[zio] val codecRegistry: Option[CodecRegistry]) {
 
   /** Secondary constructor retained for call sites that don't have a registry reference. */
@@ -53,12 +53,12 @@ class ZWorker private[zio] (
 
   /** Adds workflow to this worker.
     *
-    * Auto-registration: the codecs for every parameter and return type of `I`'s `@workflowMethod` /
-    * `@signalMethod` / `@queryMethod` methods are registered into this worker's `CodecRegistry` at compile time.
-    * This eliminates the need to chain `.addInterface[I]` on `ZWorkflowClientOptions.withCodecRegistry(...)`.
+    * Auto-registration: the codecs for every parameter and return type of `I`'s `@workflowMethod` / `@signalMethod` /
+    * `@queryMethod` methods are registered into this worker's `CodecRegistry` at compile time. This eliminates the need
+    * to chain `.addInterface[I]` on `ZWorkflowClientOptions.withCodecRegistry(...)`.
     *
-    * Opt-out: when the user supplied a custom `DataConverter` via `withDataConverter(raw)`, the registry is `None`
-    * and this auto-registration is a silent no-op — the foreign converter is trusted to handle serialization.
+    * Opt-out: when the user supplied a custom `DataConverter` via `withDataConverter(raw)`, the registry is `None` and
+    * this auto-registration is a silent no-op — the foreign converter is trusted to handle serialization.
     */
   inline def addWorkflow[I: ExtendsWorkflow]: ZWorker.AddWorkflowDsl[I] = {
     zio.temporal.json.CodecRegistry.autoRegisterInterface[I](codecRegistry)
@@ -123,12 +123,12 @@ class ZWorker private[zio] (
   /** Registers activity implementation objects with a worker. An implementation object can implement one or more
     * activity types.
     *
-    * Auto-registration: at compile time, the macro walks `A`'s base classes for every `@activityInterface`-
-    * annotated ancestor and registers each interface's codecs into this worker's `CodecRegistry`. This eliminates
-    * the need to chain `.addInterface[A]` on `ZWorkflowClientOptions.withCodecRegistry(...)`.
+    * Auto-registration: at compile time, the macro walks `A`'s base classes for every `@activityInterface`- annotated
+    * ancestor and registers each interface's codecs into this worker's `CodecRegistry`. This eliminates the need to
+    * chain `.addInterface[A]` on `ZWorkflowClientOptions.withCodecRegistry(...)`.
     *
-    * Opt-out: when the user supplied a custom `DataConverter` via `withDataConverter(raw)`, the registry is `None`
-    * and this auto-registration is a silent no-op.
+    * Opt-out: when the user supplied a custom `DataConverter` via `withDataConverter(raw)`, the registry is `None` and
+    * this auto-registration is a silent no-op.
     *
     * @see
     *   [[Worker#registerActivitiesImplementations]]
@@ -160,9 +160,9 @@ class ZWorker private[zio] (
     * the activity interface, not by the implementation.
     *
     * Auto-registration: each `ZActivityImplementationObject` carries a `registerCodecs` thunk captured at its
-    * construction time, so the element types are not lost by the `List[_]` boundary. This method invokes every
-    * thunk against this worker's registry before handing the impls to the Java SDK. Opt-out
-    * (`withDataConverter(raw)` → `codecRegistry = None`) is a silent no-op.
+    * construction time, so the element types are not lost by the `List[_]` boundary. This method invokes every thunk
+    * against this worker's registry before handing the impls to the Java SDK. Opt-out (`withDataConverter(raw)` →
+    * `codecRegistry = None`) is a silent no-op.
     */
   def addActivityImplementations(
     activityImplementationObjects: List[ZActivityImplementationObject[_]]
@@ -372,8 +372,8 @@ object ZWorker {
 
   /** Adds activity from the ZIO environment.
     *
-    * Auto-registration: `inline` so the inner `addActivityImplementation[Activity]` macro sees a concrete
-    * `Activity`. Same opt-out semantics as the instance-side method.
+    * Auto-registration: `inline` so the inner `addActivityImplementation[Activity]` macro sees a concrete `Activity`.
+    * Same opt-out semantics as the instance-side method.
     */
   inline def addActivityImplementationService[Activity <: AnyRef: ExtendsActivity: Tag]
     : ZWorker.Add[Nothing, Activity] =
@@ -410,10 +410,10 @@ object ZWorker {
 
     /** Registers workflow implementation classes with a worker. Can be called multiple times to add more types.
       *
-      * Auto-registration: the aspect's public call site (`ZWorker.addWorkflow[I].fromClass`) always has a concrete
-      * `I`, so we auto-register `I`'s codecs inside the aspect's `flatMap` — where the worker is available — by
-      * going through the (inline) `worker.addWorkflow[I]` method. Making `fromClass` itself inline keeps the macro
-      * expansion visible at the user's concrete call site instead of inside this generic class's compilation.
+      * Auto-registration: the aspect's public call site (`ZWorker.addWorkflow[I].fromClass`) always has a concrete `I`,
+      * so we auto-register `I`'s codecs inside the aspect's `flatMap` — where the worker is available — by going
+      * through the (inline) `worker.addWorkflow[I]` method. Making `fromClass` itself inline keeps the macro expansion
+      * visible at the user's concrete call site instead of inside this generic class's compilation.
       *
       * @param ctg
       *   workflow interface class tag

--- a/core/src/main/scala/zio/temporal/worker/ZWorker.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorker.scala
@@ -51,10 +51,19 @@ class ZWorker private[zio] (
       .replace("{", "(")
       .replace("}", ")")
 
-  /** Adds workflow to this worker
+  /** Adds workflow to this worker.
+    *
+    * Auto-registration: the codecs for every parameter and return type of `I`'s `@workflowMethod` /
+    * `@signalMethod` / `@queryMethod` methods are registered into this worker's `CodecRegistry` at compile time.
+    * This eliminates the need to chain `.addInterface[I]` on `ZWorkflowClientOptions.withCodecRegistry(...)`.
+    *
+    * Opt-out: when the user supplied a custom `DataConverter` via `withDataConverter(raw)`, the registry is `None`
+    * and this auto-registration is a silent no-op — the foreign converter is trusted to handle serialization.
     */
-  def addWorkflow[I: ExtendsWorkflow]: ZWorker.AddWorkflowDsl[I] =
-    new ZWorker.AddWorkflowDsl[I](worker = this, options = ZWorkflowImplementationOptions.default)
+  inline def addWorkflow[I: ExtendsWorkflow]: ZWorker.AddWorkflowDsl[I] = {
+    zio.temporal.json.CodecRegistry.autoRegisterInterface[I](codecRegistry)
+    ZWorker.buildAddWorkflowDsl[I](this, ZWorkflowImplementationOptions.default)
+  }
 
   /** @see
     *   [[addWorkflowImplementations]]
@@ -114,12 +123,22 @@ class ZWorker private[zio] (
   /** Registers activity implementation objects with a worker. An implementation object can implement one or more
     * activity types.
     *
+    * Auto-registration: at compile time, the macro walks `A`'s base classes for every `@activityInterface`-
+    * annotated ancestor and registers each interface's codecs into this worker's `CodecRegistry`. This eliminates
+    * the need to chain `.addInterface[A]` on `ZWorkflowClientOptions.withCodecRegistry(...)`.
+    *
+    * Opt-out: when the user supplied a custom `DataConverter` via `withDataConverter(raw)`, the registry is `None`
+    * and this auto-registration is a silent no-op.
+    *
     * @see
     *   [[Worker#registerActivitiesImplementations]]
     */
-  def addActivityImplementation[A <: AnyRef: ExtendsActivity](activity: A): UIO[ZWorker] = ZIO.succeed {
-    toJava.registerActivitiesImplementations(activity)
-    this
+  inline def addActivityImplementation[A <: AnyRef: ExtendsActivity](activity: A): UIO[ZWorker] = {
+    zio.temporal.json.CodecRegistry.autoRegisterActivityImpl[A](codecRegistry)
+    ZIO.succeed {
+      toJava.registerActivitiesImplementations(activity)
+      this
+    }
   }
 
   /** @see
@@ -139,10 +158,16 @@ class ZWorker private[zio] (
     *
     * <p>Implementations that share a worker must implement different interfaces as an activity type is identified by
     * the activity interface, not by the implementation.
+    *
+    * Auto-registration: each `ZActivityImplementationObject` carries a `registerCodecs` thunk captured at its
+    * construction time, so the element types are not lost by the `List[_]` boundary. This method invokes every
+    * thunk against this worker's registry before handing the impls to the Java SDK. Opt-out
+    * (`withDataConverter(raw)` → `codecRegistry = None`) is a silent no-op.
     */
   def addActivityImplementations(
     activityImplementationObjects: List[ZActivityImplementationObject[_]]
   ): UIO[ZWorker] = ZIO.succeed {
+    activityImplementationObjects.foreach(_.registerCodecs(codecRegistry))
     // safe to case as ZActivityImplementationObject type parameter is <: AnyRef
     // Note: cast is needed only for Scala 2.12
     toJava.registerActivitiesImplementations(activityImplementationObjects.map(_.value.asInstanceOf[AnyRef]): _*)
@@ -152,10 +177,12 @@ class ZWorker private[zio] (
   /** Registers activity implementation objects with a worker. An implementation object can implement one or more
     * activity types.
     *
+    * Auto-registration: same contract as [[addActivityImplementation]].
+    *
     * @see
     *   [[Worker#registerActivitiesImplementations]]
     */
-  def addActivityImplementationService[A <: AnyRef: ExtendsActivity: Tag]: URIO[A, ZWorker] = {
+  inline def addActivityImplementationService[A <: AnyRef: ExtendsActivity: Tag]: URIO[A, ZWorker] = {
     ZIO.serviceWithZIO[A] { activity =>
       addActivityImplementation[A](activity)
     }
@@ -165,6 +192,57 @@ class ZWorker private[zio] (
 object ZWorker {
 
   type Add[+LowerR, -UpperR] = ZIOAspect[LowerR, UpperR, Nothing, Any, ZWorker, ZWorker]
+
+  /** Internal builder for [[AddWorkflowDsl]] — needed because Scala 3 forbids inline methods from calling
+    * `private[zio]` constructors directly. Invoked by the inline `ZWorker#addWorkflow[I]`.
+    */
+  @zio.temporal.internalApi
+  def buildAddWorkflowDsl[I](worker: ZWorker, options: ZWorkflowImplementationOptions): AddWorkflowDsl[I] =
+    new AddWorkflowDsl[I](worker, options)
+
+  /** Internal helper used by the `inline` aspect-construction methods to avoid duplicating the anonymous-class
+    * definition at every inline call site (a Scala 3 inline hygiene issue, [E197]). The thunk is called inside the
+    * aspect's `flatMap` and is expected to return the worker (after any side-effectful registration).
+    */
+  @zio.temporal.internalApi
+  def buildWorkerAspect(thunk: ZWorker => UIO[ZWorker]): ZWorker.Add[Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
+      override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
+        zio:            ZIO[R, E, A]
+      )(implicit trace: Trace
+      ): ZIO[R, E, A] =
+        zio.flatMap(thunk)
+    }
+
+  /** Same as [[buildWorkerAspect]] but with a custom lower-bound environment type `Activity` — used by
+    * `addActivityImplementationService` which requires `Activity` in the ZIO environment.
+    */
+  @zio.temporal.internalApi
+  def buildWorkerAspectWithEnv[Activity](
+    thunk: ZWorker => URIO[Activity, ZWorker]
+  ): ZWorker.Add[Nothing, Activity] =
+    new ZIOAspect[Nothing, Activity, Nothing, Any, ZWorker, ZWorker] {
+      override def apply[R >: Nothing <: Activity, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
+        zio:            ZIO[R, E, A]
+      )(implicit trace: Trace
+      ): ZIO[R, E, A] =
+        zio.flatMap(thunk)
+    }
+
+  /** Same as [[buildWorkerAspect]] but carries an extra `R0 with Scope` environment type — used by the layer-based
+    * activity aspect methods.
+    */
+  @zio.temporal.internalApi
+  def buildScopedWorkerAspect[R0, E0](
+    thunk: ZWorker => ZIO[R0 with Scope, E0, ZWorker]
+  ): ZIOAspect[Nothing, R0 with Scope, E0, Any, ZWorker, ZWorker] =
+    new ZIOAspect[Nothing, R0 with Scope, E0, Any, ZWorker, ZWorker] {
+      override def apply[R >: Nothing <: R0 with Scope, E >: E0 <: Any, A >: ZWorker <: ZWorker](
+        zio:            ZIO[R, E, A]
+      )(implicit trace: Trace
+      ): ZIO[R, E, A] =
+        zio.flatMap(thunk)
+    }
 
   /** Adds workflow to this worker
     */
@@ -231,14 +309,15 @@ object ZWorker {
         zio.flatMap(_.addWorkflowImplementations(options, workflowImplementationClasses))
     }
 
-  def addActivityImplementation[Activity <: AnyRef: ExtendsActivity](activity: Activity): ZWorker.Add[Nothing, Any] =
-    new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
-      override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
-        zio:            ZIO[R, E, A]
-      )(implicit trace: Trace
-      ): ZIO[R, E, A] =
-        zio.flatMap(_.addActivityImplementation[Activity](activity))
-    }
+  /** Aspect-side entry point for `addActivityImplementation`.
+    *
+    * Auto-registration: `inline` so the macro expansion on the inner `worker.addActivityImplementation[Activity]`
+    * happens at the user's concrete call site where `Activity` is known.
+    */
+  inline def addActivityImplementation[Activity <: AnyRef: ExtendsActivity](
+    activity: Activity
+  ): ZWorker.Add[Nothing, Any] =
+    buildWorkerAspect(_.addActivityImplementation[Activity](activity))
 
   /** @see
     *   [[ZWorker.addActivityImplementations]]
@@ -292,34 +371,28 @@ object ZWorker {
   }
 
   /** Adds activity from the ZIO environment.
+    *
+    * Auto-registration: `inline` so the inner `addActivityImplementation[Activity]` macro sees a concrete
+    * `Activity`. Same opt-out semantics as the instance-side method.
     */
-  def addActivityImplementationService[Activity <: AnyRef: ExtendsActivity: Tag]: ZWorker.Add[Nothing, Activity] =
-    new ZIOAspect[Nothing, Activity, Nothing, Any, ZWorker, ZWorker] {
-      override def apply[R >: Nothing <: Activity, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
-        zio:            ZIO[R, E, A]
-      )(implicit trace: Trace
-      ): ZIO[R, E, A] =
-        zio.flatMap(_.addActivityImplementationService[Activity])
-    }
+  inline def addActivityImplementationService[Activity <: AnyRef: ExtendsActivity: Tag]
+    : ZWorker.Add[Nothing, Activity] =
+    buildWorkerAspectWithEnv[Activity](_.addActivityImplementationService[Activity])
 
   /** Adds activity from the given [[ZLayer]]
+    *
+    * Auto-registration: `inline`, same reason as [[addActivityImplementationService]].
     *
     * @param layer
     *   the activity implementation object as a [[ZLayer]]
     */
-  def addActivityImplementationLayer[R0, Activity <: AnyRef: ExtendsActivity: Tag, E0](
+  inline def addActivityImplementationLayer[R0, Activity <: AnyRef: ExtendsActivity: Tag, E0](
     layer: ZLayer[R0, E0, Activity]
   ): ZIOAspect[Nothing, R0 with Scope, E0, Any, ZWorker, ZWorker] =
-    new ZIOAspect[Nothing, R0 with Scope, E0, Any, ZWorker, ZWorker] {
-      override def apply[R >: Nothing <: R0 with Scope, E >: E0 <: Any, A >: ZWorker <: ZWorker](
-        zio:            ZIO[R, E, A]
-      )(implicit trace: Trace
-      ): ZIO[R, E, A] =
-        zio.flatMap { worker =>
-          layer.build.flatMap { env =>
-            worker.addActivityImplementation(env.get[Activity])
-          }
-        }
+    buildScopedWorkerAspect[R0, E0] { worker =>
+      layer.build.flatMap { env =>
+        worker.addActivityImplementation[Activity](env.get[Activity])
+      }
     }
 
   /** Allows building workers using [[ZIOAspect]]
@@ -337,23 +410,24 @@ object ZWorker {
 
     /** Registers workflow implementation classes with a worker. Can be called multiple times to add more types.
       *
+      * Auto-registration: the aspect's public call site (`ZWorker.addWorkflow[I].fromClass`) always has a concrete
+      * `I`, so we auto-register `I`'s codecs inside the aspect's `flatMap` — where the worker is available — by
+      * going through the (inline) `worker.addWorkflow[I]` method. Making `fromClass` itself inline keeps the macro
+      * expansion visible at the user's concrete call site instead of inside this generic class's compilation.
+      *
       * @param ctg
       *   workflow interface class tag
       * @see
       *   [[Worker#registerWorkflowImplementationTypes]]
       */
-    def fromClass(implicit
+    inline def fromClass(implicit
       ctg:                         ClassTag[I],
       isConcreteClass:             IsConcreteClass[I],
       hasPublicNullaryConstructor: HasPublicNullaryConstructor[I]
-    ): ZWorker.Add[Nothing, Any] =
-      new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
-        override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
-          zio:            ZIO[R, E, A]
-        )(implicit trace: Trace
-        ): ZIO[R, E, A] =
-          zio.flatMap(_.addWorkflow[I].withOptions(options).fromClass)
-      }
+    ): ZWorker.Add[Nothing, Any] = {
+      val capturedOptions = options
+      ZWorker.buildWorkerAspect(_.addWorkflow[I].withOptions(capturedOptions).fromClass)
+    }
 
     /** Registers workflow implementation classes with a worker. Can be called multiple times to add more types.
       *
@@ -362,19 +436,15 @@ object ZWorker {
       * @see
       *   [[Worker#registerWorkflowImplementationTypes]]
       */
-    def fromClass(
+    inline def fromClass(
       cls: Class[I]
     )(implicit
       isConcreteClass:             IsConcreteClass[I],
       hasPublicNullaryConstructor: HasPublicNullaryConstructor[I]
-    ): ZWorker.Add[Nothing, Any] =
-      new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
-        override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
-          zio:            ZIO[R, E, A]
-        )(implicit trace: Trace
-        ): ZIO[R, E, A] =
-          zio.flatMap(_.addWorkflow[I].withOptions(options).fromClass(cls))
-      }
+    ): ZWorker.Add[Nothing, Any] = {
+      val capturedOptions = options
+      ZWorker.buildWorkerAspect(_.addWorkflow[I].withOptions(capturedOptions).fromClass(cls))
+    }
 
     /** Configures a factory to use when an instance of a workflow implementation is created. The only valid use for
       * this method is unit testing, specifically to instantiate mocks that implement child workflows. An example of
@@ -389,14 +459,10 @@ object ZWorker {
       * @see
       *   [[Worker#addWorkflowImplementationFactory]]
       */
-    def from[Workflow <: I](f: => Workflow)(implicit ctg: ClassTag[I]): ZWorker.Add[Nothing, Any] =
-      new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
-        override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
-          zio:            ZIO[R, E, A]
-        )(implicit trace: Trace
-        ): ZIO[R, E, A] =
-          zio.flatMap(_.addWorkflow[I].withOptions(options).from(f))
-      }
+    inline def from[Workflow <: I](inline f: => Workflow)(implicit ctg: ClassTag[I]): ZWorker.Add[Nothing, Any] = {
+      val capturedOptions = options
+      ZWorker.buildWorkerAspect(_.addWorkflow[I].withOptions(capturedOptions).from(f))
+    }
 
     /** Configures a factory to use when an instance of a workflow implementation is created. The only valid use for
       * this method is unit testing, specifically to instantiate mocks that implement child workflows. An example of
@@ -409,14 +475,10 @@ object ZWorker {
       * @see
       *   [[Worker#addWorkflowImplementationFactory]]
       */
-    def from(cls: Class[I], f: () => I): ZWorker.Add[Nothing, Any] =
-      new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
-        override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
-          zio:            ZIO[R, E, A]
-        )(implicit trace: Trace
-        ): ZIO[R, E, A] =
-          zio.flatMap(_.addWorkflow[I].withOptions(options).from(cls, f))
-      }
+    inline def from(cls: Class[I], f: () => I): ZWorker.Add[Nothing, Any] = {
+      val capturedOptions = options
+      ZWorker.buildWorkerAspect(_.addWorkflow[I].withOptions(capturedOptions).from(cls, f))
+    }
   }
 
   /** Allows building workers

--- a/core/src/main/scala/zio/temporal/worker/ZWorkerFactory.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorkerFactory.scala
@@ -2,14 +2,25 @@ package zio.temporal.worker
 
 import io.temporal.worker.WorkerFactory
 import zio._
+import zio.temporal.json.CodecRegistry
 import zio.temporal.workflow.ZWorkflowClient
 
 /** Maintains worker creation and lifecycle.
   *
+  * The `codecRegistry` is propagated from the upstream `ZWorkflowClient` (which took it from
+  * `ZWorkflowClientOptions`) so every worker created by this factory shares the same registry instance — the
+  * client and its workers therefore auto-register into the same append-only registry that the data converter
+  * reads on encode/decode.
+  *
   * @see
   *   [[WorkerFactory]]
   */
-final class ZWorkerFactory private[zio] (val toJava: WorkerFactory) {
+final class ZWorkerFactory private[zio] (
+  val toJava:                     WorkerFactory,
+  private[zio] val codecRegistry: Option[CodecRegistry]) {
+
+  /** Secondary constructor retained for call sites that don't have a registry reference. */
+  private[zio] def this(toJava: WorkerFactory) = this(toJava, None)
 
   /** Allows to setup [[ZWorkerFactory]] with guaranteed finalization.
     */
@@ -64,7 +75,7 @@ final class ZWorkerFactory private[zio] (val toJava: WorkerFactory) {
     */
   def newWorker(taskQueue: String, options: ZWorkerOptions = ZWorkerOptions.default): UIO[ZWorker] =
     ZIO.succeedBlocking(
-      new ZWorker(toJava.newWorker(taskQueue, options.toJava))
+      new ZWorker(toJava.newWorker(taskQueue, options.toJava), codecRegistry)
     )
 
   /** @param taskQueue
@@ -74,7 +85,7 @@ final class ZWorkerFactory private[zio] (val toJava: WorkerFactory) {
     */
   def getWorker(taskQueue: String): UIO[Option[ZWorker]] =
     ZIO
-      .attemptBlocking(new ZWorker(toJava.getWorker(taskQueue)))
+      .attemptBlocking(new ZWorker(toJava.getWorker(taskQueue), codecRegistry))
       .refineToOrDie[IllegalArgumentException]
       .option
 }
@@ -112,11 +123,13 @@ object ZWorkerFactory {
   val make: URLayer[ZWorkflowClient with ZWorkerFactoryOptions, ZWorkerFactory] =
     ZLayer.fromZIO {
       ZIO.environmentWith[ZWorkflowClient with ZWorkerFactoryOptions] { environment =>
+        val client = environment.get[ZWorkflowClient]
         new ZWorkerFactory(
           WorkerFactory.newInstance(
-            environment.get[ZWorkflowClient].toJava,
+            client.toJava,
             environment.get[ZWorkerFactoryOptions].toJava
-          )
+          ),
+          client.codecRegistry
         )
       }
     }

--- a/core/src/main/scala/zio/temporal/worker/ZWorkerFactory.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorkerFactory.scala
@@ -7,16 +7,15 @@ import zio.temporal.workflow.ZWorkflowClient
 
 /** Maintains worker creation and lifecycle.
   *
-  * The `codecRegistry` is propagated from the upstream `ZWorkflowClient` (which took it from
-  * `ZWorkflowClientOptions`) so every worker created by this factory shares the same registry instance — the
-  * client and its workers therefore auto-register into the same append-only registry that the data converter
-  * reads on encode/decode.
+  * The `codecRegistry` is propagated from the upstream `ZWorkflowClient` (which took it from `ZWorkflowClientOptions`)
+  * so every worker created by this factory shares the same registry instance — the client and its workers therefore
+  * auto-register into the same append-only registry that the data converter reads on encode/decode.
   *
   * @see
   *   [[WorkerFactory]]
   */
 final class ZWorkerFactory private[zio] (
-  val toJava:                     WorkerFactory,
+  val toJava: WorkerFactory,
   private[zio] val codecRegistry: Option[CodecRegistry]) {
 
   /** Secondary constructor retained for call sites that don't have a registry reference. */

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowClient.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowClient.scala
@@ -34,20 +34,29 @@ final class ZWorkflowClient private[zio] (
   def newActivityCompletionClient: UIO[ActivityCompletionClient] =
     ZIO.succeedBlocking(toJava.newActivityCompletionClient())
 
-  /** Creates new typed workflow stub builder
+  /** Creates new typed workflow stub builder.
+    *
+    * Auto-registration: the codecs for every parameter and return type of `A`'s `@workflowMethod` /
+    * `@signalMethod` / `@queryMethod` methods are registered into this client's `CodecRegistry` at compile time.
+    * Opt-out (`withDataConverter(raw)` → `codecRegistry = None`) is a silent no-op.
+    *
     * @tparam A
     *   workflow interface
     * @return
     *   builder instance
     */
   @deprecated("Use newWorkflowStub accepting ZWorkerOptions", since = "0.6.0")
-  def newWorkflowStub[A: ClassTag: IsWorkflow]: ZWorkflowStubBuilderTaskQueueDsl.Of[A] =
-    new ZWorkflowStubBuilderTaskQueueDsl.Of[A](TemporalWorkflowFacade.createWorkflowStubTyped[A](toJava))
+  inline def newWorkflowStub[A: ClassTag: IsWorkflow]: ZWorkflowStubBuilderTaskQueueDsl.Of[A] = {
+    zio.temporal.json.CodecRegistry.autoRegisterInterface[A](codecRegistry)
+    ZWorkflowClient.buildTaskQueueDsl[A](this)
+  }
 
   /** Creates workflow client stub that can be used to start a single workflow execution. The first call must be to a
     * method annotated with @[[zio.temporal.workflowMethod]]. After workflow is started it can be also used to send
     * signals or queries to it. IMPORTANT! Stub is per workflow instance. So new stub should be created for each new
     * one.
+    *
+    * Auto-registration: same contract as above. Applies to all three `newWorkflowStub[A]` overloads.
     *
     * @tparam A
     *   interface that given workflow implements
@@ -56,8 +65,10 @@ final class ZWorkflowClient private[zio] (
     * @return
     *   Stub that implements workflowInterface and can be used to start workflow and signal or query it after the start.
     */
-  def newWorkflowStub[A: ClassTag: IsWorkflow](options: ZWorkflowOptions): UIO[ZWorkflowStub.Of[A]] =
+  inline def newWorkflowStub[A: ClassTag: IsWorkflow](options: ZWorkflowOptions): UIO[ZWorkflowStub.Of[A]] = {
+    zio.temporal.json.CodecRegistry.autoRegisterInterface[A](codecRegistry)
     TemporalWorkflowFacade.createWorkflowStubTyped[A](toJava).apply(options.toJava)
+  }
 
   /** Creates workflow client stub for a known execution. Use it to send signals or queries to a running workflow. Do
     * not call methods annotated with @[[zio.temporal.workflowMethod]].
@@ -71,18 +82,13 @@ final class ZWorkflowClient private[zio] (
     * @return
     *   Stub that implements workflowInterface and can be used to signal or query it.
     */
-  def newWorkflowStub[A: ClassTag: IsWorkflow](
+  inline def newWorkflowStub[A: ClassTag: IsWorkflow](
     workflowId: String,
     runId:      Option[String] = None
-  ): UIO[ZWorkflowStub.Of[A]] =
-    ZIO.succeed {
-      ZWorkflowStub.Of[A](
-        new ZWorkflowStubImpl(
-          toJava.newUntypedWorkflowStub(workflowId, runId.toJava, Option.empty[String].toJava),
-          ClassTagUtils.classOf[A]
-        )
-      )
-    }
+  ): UIO[ZWorkflowStub.Of[A]] = {
+    zio.temporal.json.CodecRegistry.autoRegisterInterface[A](codecRegistry)
+    ZWorkflowClient.buildWorkflowStubFromIds[A](this, workflowId, runId)
+  }
 
   /** Creates new untyped type workflow stub builder
     *
@@ -224,6 +230,29 @@ final class ZWorkflowClient private[zio] (
 }
 
 object ZWorkflowClient {
+
+  /** Internal helper used by `inline def newWorkflowStub[A]` (no args) — needed because Scala 3 inline methods
+    * cannot directly invoke `private[zio]` constructors. Package-private so only the inline site can call it.
+    */
+  @zio.temporal.internalApi
+  def buildTaskQueueDsl[A: ClassTag](client: ZWorkflowClient): ZWorkflowStubBuilderTaskQueueDsl.Of[A] =
+    new ZWorkflowStubBuilderTaskQueueDsl.Of[A](TemporalWorkflowFacade.createWorkflowStubTyped[A](client.toJava))
+
+  /** Internal helper used by `inline def newWorkflowStub[A](workflowId, runId)`. */
+  @zio.temporal.internalApi
+  def buildWorkflowStubFromIds[A: ClassTag](
+    client:     ZWorkflowClient,
+    workflowId: String,
+    runId:      Option[String]
+  ): UIO[ZWorkflowStub.Of[A]] =
+    ZIO.succeed {
+      ZWorkflowStub.Of[A](
+        new ZWorkflowStubImpl(
+          client.toJava.newUntypedWorkflowStub(workflowId, runId.toJava, Option.empty[String].toJava),
+          ClassTagUtils.classOf[A]
+        )
+      )
+    }
 
   /** Create [[ZWorkflowClient]] instance.
     *

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowClient.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowClient.scala
@@ -11,17 +11,17 @@ import scala.reflect.ClassTag
 
 /** Represents Temporal workflow client
   *
-  * The `codecRegistry` carried here is the ''same'' `CodecRegistry` instance that backs this client's
-  * `DataConverter` (when the default zio-json data converter is in use). Auto-registration call sites
-  * (`newWorkflowStub[A]`, `ZWorker.addWorkflow[I]`, …) mutate it at invocation time so users no longer need to
-  * chain `.addInterface[...]` by hand. `None` indicates the user supplied a custom `DataConverter` via
-  * `withDataConverter(raw)`; in that case auto-registration is a silent no-op.
+  * The `codecRegistry` carried here is the ''same'' `CodecRegistry` instance that backs this client's `DataConverter`
+  * (when the default zio-json data converter is in use). Auto-registration call sites (`newWorkflowStub[A]`,
+  * `ZWorker.addWorkflow[I]`, …) mutate it at invocation time so users no longer need to chain `.addInterface[...]` by
+  * hand. `None` indicates the user supplied a custom `DataConverter` via `withDataConverter(raw)`; in that case
+  * auto-registration is a silent no-op.
   *
   * @see
   *   [[WorkflowClient]]
   */
 final class ZWorkflowClient private[zio] (
-  val toJava:                     WorkflowClient,
+  val toJava: WorkflowClient,
   private[zio] val codecRegistry: Option[CodecRegistry]) {
 
   /** Secondary constructor retained for call sites that don't have a registry reference. */
@@ -36,9 +36,9 @@ final class ZWorkflowClient private[zio] (
 
   /** Creates new typed workflow stub builder.
     *
-    * Auto-registration: the codecs for every parameter and return type of `A`'s `@workflowMethod` /
-    * `@signalMethod` / `@queryMethod` methods are registered into this client's `CodecRegistry` at compile time.
-    * Opt-out (`withDataConverter(raw)` → `codecRegistry = None`) is a silent no-op.
+    * Auto-registration: the codecs for every parameter and return type of `A`'s `@workflowMethod` / `@signalMethod` /
+    * `@queryMethod` methods are registered into this client's `CodecRegistry` at compile time. Opt-out
+    * (`withDataConverter(raw)` → `codecRegistry = None`) is a silent no-op.
     *
     * @tparam A
     *   workflow interface
@@ -231,8 +231,8 @@ final class ZWorkflowClient private[zio] (
 
 object ZWorkflowClient {
 
-  /** Internal helper used by `inline def newWorkflowStub[A]` (no args) — needed because Scala 3 inline methods
-    * cannot directly invoke `private[zio]` constructors. Package-private so only the inline site can call it.
+  /** Internal helper used by `inline def newWorkflowStub[A]` (no args) — needed because Scala 3 inline methods cannot
+    * directly invoke `private[zio]` constructors. Package-private so only the inline site can call it.
     */
   @zio.temporal.internalApi
   def buildTaskQueueDsl[A: ClassTag](client: ZWorkflowClient): ZWorkflowStubBuilderTaskQueueDsl.Of[A] =
@@ -257,12 +257,12 @@ object ZWorkflowClient {
   /** Create [[ZWorkflowClient]] instance.
     *
     * The `codecRegistry` carried by [[ZWorkflowClientOptions]] is threaded into the resulting client so the
-    * auto-registration call sites (`ZWorker.addWorkflow[I]`, `newWorkflowStub[A]`, …) can populate it at their
-    * natural usage points, eliminating the need for manual `.addInterface[...]` calls.
+    * auto-registration call sites (`ZWorker.addWorkflow[I]`, `newWorkflowStub[A]`, …) can populate it at their natural
+    * usage points, eliminating the need for manual `.addInterface[...]` calls.
     *
-    * The registry is allowed to start empty: codecs are added incrementally by `addWorkflow` / `newWorkflowStub`
-    * / `addActivityImplementation`. If the user forgets to register any workflow or activity type at all, the
-    * first payload encode produces a clear "No ZTemporalCodec registered for runtime class …" error from
+    * The registry is allowed to start empty: codecs are added incrementally by `addWorkflow` / `newWorkflowStub` /
+    * `addActivityImplementation`. If the user forgets to register any workflow or activity type at all, the first
+    * payload encode produces a clear "No ZTemporalCodec registered for runtime class …" error from
     * `ZioJsonPayloadConverter`.
     *
     * @see

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowClient.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowClient.scala
@@ -4,16 +4,28 @@ import io.temporal.client.{ActivityCompletionClient, BuildIdOperation, WorkflowC
 import zio._
 import zio.stream._
 import zio.temporal.internal.{ClassTagUtils, TemporalInteraction, TemporalWorkflowFacade}
+import zio.temporal.json.CodecRegistry
 import zio.temporal.{TemporalIO, ZHistoryEvent, ZWorkflowExecutionHistory, ZWorkflowExecutionMetadata}
 import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 /** Represents Temporal workflow client
   *
+  * The `codecRegistry` carried here is the ''same'' `CodecRegistry` instance that backs this client's
+  * `DataConverter` (when the default zio-json data converter is in use). Auto-registration call sites
+  * (`newWorkflowStub[A]`, `ZWorker.addWorkflow[I]`, …) mutate it at invocation time so users no longer need to
+  * chain `.addInterface[...]` by hand. `None` indicates the user supplied a custom `DataConverter` via
+  * `withDataConverter(raw)`; in that case auto-registration is a silent no-op.
+  *
   * @see
   *   [[WorkflowClient]]
   */
-final class ZWorkflowClient private[zio] (val toJava: WorkflowClient) {
+final class ZWorkflowClient private[zio] (
+  val toJava:                     WorkflowClient,
+  private[zio] val codecRegistry: Option[CodecRegistry]) {
+
+  /** Secondary constructor retained for call sites that don't have a registry reference. */
+  private[zio] def this(toJava: WorkflowClient) = this(toJava, None)
 
   /** Creates new ActivityCompletionClient
     * @see
@@ -215,11 +227,14 @@ object ZWorkflowClient {
 
   /** Create [[ZWorkflowClient]] instance.
     *
-    * Fail-fast: when the default zio-json data converter is in use (i.e. `ZWorkflowClientOptions.codecRegistry` is
-    * `Some`), the registry is verified to be non-empty. An empty registry guarantees that every workflow/activity call
-    * will fail at runtime with `"No ZTemporalCodec registered…"` — almost always because the caller forgot to chain
-    * `@@ ZWorkflowClientOptions.withCodecRegistry(...).addInterface[…]`. Failing at client construction gives a precise
-    * error pointing at the setup code instead.
+    * The `codecRegistry` carried by [[ZWorkflowClientOptions]] is threaded into the resulting client so the
+    * auto-registration call sites (`ZWorker.addWorkflow[I]`, `newWorkflowStub[A]`, …) can populate it at their
+    * natural usage points, eliminating the need for manual `.addInterface[...]` calls.
+    *
+    * The registry is allowed to start empty: codecs are added incrementally by `addWorkflow` / `newWorkflowStub`
+    * / `addActivityImplementation`. If the user forgets to register any workflow or activity type at all, the
+    * first payload encode produces a clear "No ZTemporalCodec registered for runtime class …" error from
+    * `ZioJsonPayloadConverter`.
     *
     * @see
     *   [[WorkflowClient]]
@@ -227,35 +242,16 @@ object ZWorkflowClient {
   val make: URLayer[ZWorkflowServiceStubs with ZWorkflowClientOptions, ZWorkflowClient] =
     ZLayer.fromZIO {
       ZIO.environmentWithZIO[ZWorkflowServiceStubs with ZWorkflowClientOptions] { environment =>
-        val options            = environment.get[ZWorkflowClientOptions]
-        val emptyRegistryCheck = options.codecRegistry match {
-          case Some(registry) if registry.size == 0 =>
-            ZIO.die(
-              new IllegalStateException(
-                "ZWorkflowClient was built with an empty CodecRegistry — the default zio-json data converter " +
-                  "has no codecs registered, so every workflow/activity call will fail at runtime with " +
-                  "`No ZTemporalCodec registered for runtime class …`.\n" +
-                  "Register your workflow and activity interfaces at client construction:\n\n" +
-                  "    ZWorkflowClientOptions.make @@\n" +
-                  "      ZWorkflowClientOptions.withCodecRegistry(\n" +
-                  "        new CodecRegistry()\n" +
-                  "          .addInterface[YourWorkflow]\n" +
-                  "          .addInterface[YourActivity]\n" +
-                  "      )\n\n" +
-                  "Or supply a custom DataConverter via `.withDataConverter(...)` to opt out of this check."
-              )
-            )
-          case _ => ZIO.unit
+        val options = environment.get[ZWorkflowClientOptions]
+        ZIO.succeedBlocking {
+          new ZWorkflowClient(
+            WorkflowClient.newInstance(
+              environment.get[ZWorkflowServiceStubs].toJava,
+              options.toJava
+            ),
+            options.codecRegistry
+          )
         }
-        emptyRegistryCheck *>
-          ZIO.succeedBlocking {
-            new ZWorkflowClient(
-              WorkflowClient.newInstance(
-                environment.get[ZWorkflowServiceStubs].toJava,
-                options.toJava
-              )
-            )
-          }
       }
     }
 }

--- a/core/src/test/scala/zio/temporal/json/CodecRegistryAutoRegisterSpec.scala
+++ b/core/src/test/scala/zio/temporal/json/CodecRegistryAutoRegisterSpec.scala
@@ -1,0 +1,134 @@
+package zio.temporal.json
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import zio.json.JsonCodec
+import zio.temporal.*
+
+/** Unit tests for `CodecRegistry.autoRegisterInterface[I]` and `CodecRegistry.autoRegisterActivityImpl[A]`.
+  *
+  * These exercise the same macro machinery as `addInterface[I]` but through the auto-registration entry points
+  * that the inline methods on `ZWorker` / `ZWorkflowClient` invoke. Expected behaviours:
+  *
+  *   1. When the registry is `Some(r)`, codecs for `I`'s boundary methods are registered into `r`.
+  *   2. When the registry is `None`, the call is a silent no-op — no side effects, no compile error.
+  *   3. Repeated calls are idempotent (registry ends up the same).
+  *   4. The macro walks supertype chains for `@workflowInterface` / `@activityInterface` ancestors so the user
+  *      can pass an implementation class as the type parameter.
+  */
+class CodecRegistryAutoRegisterSpec extends AnyWordSpec with Matchers {
+
+  import CodecRegistryAutoRegisterSpec.*
+
+  "CodecRegistry.autoRegisterInterface" should {
+
+    "populate Some(registry) with every boundary-method parameter and return type" in {
+      val r = new CodecRegistry()
+      CodecRegistry.autoRegisterInterface[MyAutoWorkflow](Some(r))
+      r.encoderForClass(classOf[AutoUser]) should not be null
+      r.decoderForType(classOf[AutoUser]) should not be null
+      r.decoderForType(classOf[String]) should not be null
+    }
+
+    "be a silent no-op when registry is None" in {
+      noException should be thrownBy {
+        CodecRegistry.autoRegisterInterface[MyAutoWorkflow](None)
+      }
+      // Build a separate registry to confirm None doesn't magically populate one.
+      val r = new CodecRegistry()
+      r.size shouldBe 0
+    }
+
+    "be idempotent when called multiple times with the same interface" in {
+      val r = new CodecRegistry()
+      CodecRegistry.autoRegisterInterface[MyAutoWorkflow](Some(r))
+      val sizeAfterFirst = r.size
+      CodecRegistry.autoRegisterInterface[MyAutoWorkflow](Some(r))
+      CodecRegistry.autoRegisterInterface[MyAutoWorkflow](Some(r))
+      r.size shouldBe sizeAfterFirst
+    }
+
+    "walk to @workflowInterface ancestor when given an implementation class" in {
+      val r = new CodecRegistry()
+      CodecRegistry.autoRegisterInterface[MyAutoWorkflowImpl](Some(r))
+      // The impl has no @workflowMethod directly — codecs come from walking to MyAutoWorkflow.
+      r.encoderForClass(classOf[AutoUser]) should not be null
+      r.decoderForType(classOf[AutoUser]) should not be null
+    }
+
+    "silently skip types without a summonable codec (non-strict mode)" in {
+      val r = new CodecRegistry()
+      // WorkflowWithUncodecableType's method takes `Any` which has no ZTemporalCodec. Non-strict mode
+      // must skip it rather than abort compilation.
+      CodecRegistry.autoRegisterInterface[WorkflowWithUncodecableType](Some(r))
+      // The method also takes `String` which does have a codec, so that should still be registered.
+      r.decoderForType(classOf[String]) should not be null
+    }
+  }
+
+  "CodecRegistry.autoRegisterActivityImpl" should {
+
+    "register codecs for the @activityInterface ancestor(s) of the impl class" in {
+      val r = new CodecRegistry()
+      CodecRegistry.autoRegisterActivityImpl[MyAutoActivityImpl](Some(r))
+      r.encoderForClass(classOf[AutoUser]) should not be null
+      r.decoderForType(classOf[Int]) should not be null
+    }
+
+    "be a silent no-op when registry is None" in {
+      noException should be thrownBy {
+        CodecRegistry.autoRegisterActivityImpl[MyAutoActivityImpl](None)
+      }
+    }
+
+    "handle an impl that implements multiple @activityInterface types" in {
+      val r = new CodecRegistry()
+      CodecRegistry.autoRegisterActivityImpl[MultiActivityImpl](Some(r))
+      // Both interfaces' referenced types should be registered.
+      r.decoderForType(classOf[AutoUser]) should not be null
+      r.decoderForType(classOf[AutoOrder]) should not be null
+    }
+  }
+}
+
+object CodecRegistryAutoRegisterSpec {
+  final case class AutoUser(id: Int, name: String) derives JsonCodec
+  final case class AutoOrder(sku: String, quantity: Int) derives JsonCodec
+
+  @workflowInterface
+  trait MyAutoWorkflow {
+    @workflowMethod
+    def run(user: AutoUser): String
+  }
+
+  // An implementation class — the macro should walk to its MyAutoWorkflow ancestor.
+  class MyAutoWorkflowImpl extends MyAutoWorkflow {
+    override def run(user: AutoUser): String = user.name
+  }
+
+  // Has a method with an uncodec-able type parameter (Any).
+  @workflowInterface
+  trait WorkflowWithUncodecableType {
+    @workflowMethod
+    def process(value: Any, label: String): String
+  }
+
+  @activityInterface
+  trait MyAutoActivity {
+    def save(user: AutoUser): Int
+  }
+
+  class MyAutoActivityImpl extends MyAutoActivity {
+    override def save(user: AutoUser): Int = user.id
+  }
+
+  @activityInterface
+  trait OrderActivity {
+    def place(order: AutoOrder): String
+  }
+
+  class MultiActivityImpl extends MyAutoActivity with OrderActivity {
+    override def save(user: AutoUser): Int   = user.id
+    override def place(order: AutoOrder): String = order.sku
+  }
+}

--- a/core/src/test/scala/zio/temporal/json/CodecRegistryAutoRegisterSpec.scala
+++ b/core/src/test/scala/zio/temporal/json/CodecRegistryAutoRegisterSpec.scala
@@ -7,14 +7,14 @@ import zio.temporal.*
 
 /** Unit tests for `CodecRegistry.autoRegisterInterface[I]` and `CodecRegistry.autoRegisterActivityImpl[A]`.
   *
-  * These exercise the same macro machinery as `addInterface[I]` but through the auto-registration entry points
-  * that the inline methods on `ZWorker` / `ZWorkflowClient` invoke. Expected behaviours:
+  * These exercise the same macro machinery as `addInterface[I]` but through the auto-registration entry points that the
+  * inline methods on `ZWorker` / `ZWorkflowClient` invoke. Expected behaviours:
   *
   *   1. When the registry is `Some(r)`, codecs for `I`'s boundary methods are registered into `r`.
   *   2. When the registry is `None`, the call is a silent no-op — no side effects, no compile error.
   *   3. Repeated calls are idempotent (registry ends up the same).
-  *   4. The macro walks supertype chains for `@workflowInterface` / `@activityInterface` ancestors so the user
-  *      can pass an implementation class as the type parameter.
+  *   4. The macro walks supertype chains for `@workflowInterface` / `@activityInterface` ancestors so the user can pass
+  *      an implementation class as the type parameter.
   */
 class CodecRegistryAutoRegisterSpec extends AnyWordSpec with Matchers {
 
@@ -128,7 +128,7 @@ object CodecRegistryAutoRegisterSpec {
   }
 
   class MultiActivityImpl extends MyAutoActivity with OrderActivity {
-    override def save(user: AutoUser): Int   = user.id
+    override def save(user:   AutoUser): Int     = user.id
     override def place(order: AutoOrder): String = order.sku
   }
 }

--- a/integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala
+++ b/integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala
@@ -1,0 +1,120 @@
+package zio.temporal
+
+import io.temporal.common.converter.{DataConverter, PayloadConverter}
+import io.temporal.api.common.v1.Payload
+import io.temporal.common.converter.DefaultDataConverter
+import zio._
+import zio.logging.backend.SLF4J
+import zio.temporal.activity.{ZActivityImplementationObject, ZActivityOptions, ZActivityRunOptions}
+import zio.temporal.fixture._
+import zio.temporal.json.{CodecRegistry, ZTemporalCodec, ZioJsonDataConverter}
+import zio.temporal.testkit._
+import zio.temporal.worker._
+import zio.temporal.workflow._
+import zio.test._
+
+/** End-to-end integration coverage for the auto-registration feature. Contrast with [[BaseTemporalSpec]] which
+  * wires every spec with the shared [[FixtureCodecRegistry.all]] — here we intentionally wire clients with an
+  * empty `CodecRegistry` to verify that the auto-reg call sites fill it in correctly at worker / stub-creation
+  * time.
+  */
+object AutoRegistrationSpec extends ZIOSpecDefault {
+  override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
+    testEnvironment ++ Runtime.removeDefaultLoggers ++ SLF4J.slf4j
+
+  /** A `ZWorkflowClientOptions` with an empty registry — auto-reg must populate it via the call sites. */
+  private val emptyRegistryClientOptions: ULayer[ZWorkflowClientOptions] =
+    ZWorkflowClientOptions.make.orDie
+
+  private val emptyRegistryWorkflowEnv: ULayer[ZTestWorkflowEnvironment[Any]] =
+    ZLayer.make[ZTestWorkflowEnvironment[Any]](
+      emptyRegistryClientOptions,
+      ZWorkerFactoryOptions.make.orDie,
+      ZTestEnvironmentOptions.make,
+      ZTestWorkflowEnvironment.make[Any]
+    )
+
+  override val spec = suite("Auto-registration of codecs at worker/stub sites")(
+    test("workflow auto-registers its interface codecs via addWorkflow[I] and newWorkflowStub[I]") {
+      val taskQueue = "auto-reg-workflow-queue"
+
+      for {
+        workflowId <- ZIO.randomWith(_.nextUUID)
+        // No manual addInterface — auto-reg happens on addWorkflow and newWorkflowStub.
+        _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+               ZWorker.addWorkflow[SampleWorkflowImpl].fromClass
+        _        <- ZTestWorkflowEnvironment.setup()
+        workflow <- ZTestWorkflowEnvironment.newWorkflowStub[SampleWorkflow](
+                      ZWorkflowOptions
+                        .withWorkflowId(workflowId.toString)
+                        .withTaskQueue(taskQueue)
+                        .withWorkflowRunTimeout(10.second)
+                    )
+        result <- ZWorkflowStub.execute(workflow.echo("auto-reg"))
+      } yield assertTrue(result == "auto-reg")
+    }.provideSomeLayer[Scope](emptyRegistryWorkflowEnv) @@ TestAspect.withLiveClock,
+    test("activity auto-registers its @activityInterface codecs via addActivityImplementation") {
+      val taskQueue = "auto-reg-activity-queue"
+
+      for {
+        workflowId <- ZIO.randomWith(_.nextUUID)
+        // Registers both PromiseWorkflow (interface) and PromiseActivityImpl (impl — walks to PromiseActivity)
+        _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+               ZWorker.addWorkflow[PromiseWorkflowImpl].fromClass @@
+               ZWorker.addActivityImplementation(new PromiseActivityImpl(x => x * 2, x => x + 1))
+        _        <- ZTestWorkflowEnvironment.setup()
+        workflow <- ZTestWorkflowEnvironment.newWorkflowStub[PromiseWorkflow](
+                      ZWorkflowOptions
+                        .withWorkflowId(workflowId.toString)
+                        .withTaskQueue(taskQueue)
+                        .withWorkflowRunTimeout(10.second)
+                    )
+        // foo(3) = 6, bar(4) = 5, sum = 11
+        result <- ZWorkflowStub.execute(workflow.fooBar(3, 4))
+      } yield assertTrue(result == 11)
+    }.provideSomeLayer[Scope](emptyRegistryWorkflowEnv) @@ TestAspect.withLiveClock,
+    test("auto-reg is idempotent: the same workflow added on three workers yields one codec entry") {
+      // Build three workers on different task queues, register the same workflow on each, and inspect the
+      // shared registry. CodecRegistry.register already dedupes identical codecs, so the registry should hold
+      // exactly one SampleWorkflow's codec entries (plus its String return/parameter codecs), not three of each.
+      for {
+        _ <- ZTestWorkflowEnvironment.newWorker("dedup-queue-1") @@
+               ZWorker.addWorkflow[SampleWorkflowImpl].fromClass
+        _ <- ZTestWorkflowEnvironment.newWorker("dedup-queue-2") @@
+               ZWorker.addWorkflow[SampleWorkflowImpl].fromClass
+        _ <- ZTestWorkflowEnvironment.newWorker("dedup-queue-3") @@
+               ZWorker.addWorkflow[SampleWorkflowImpl].fromClass
+        registry <- ZIO.serviceWith[ZTestWorkflowEnvironment[Any]](
+                      _.codecRegistry.getOrElse(throw new AssertionError("registry should be Some here"))
+                    )
+        typeNames = registry.registeredTypeNames.toSet
+      } yield assertTrue(
+        // SampleWorkflow.echo(str: String): String — String codec is registered exactly once.
+        typeNames.count(_ == "java.lang.String") == 1
+      )
+    }.provideSomeLayer[Scope](emptyRegistryWorkflowEnv),
+    test("opt-out: when withDataConverter(raw) is used, the registry is None and auto-reg is a no-op") {
+      // Use a mock DataConverter that just echoes a fixed payload. The important thing is that setting it via
+      // withDataConverter clears codecRegistry to None, and auto-reg must then be a silent no-op.
+      val rawConverter = DefaultDataConverter.STANDARD_INSTANCE
+      val options      =
+        ZWorkflowClientOptions
+          .make @@ ZWorkflowClientOptions.withDataConverter(rawConverter)
+
+      val customEnvLayer: ULayer[ZTestWorkflowEnvironment[Any]] =
+        ZLayer.make[ZTestWorkflowEnvironment[Any]](
+          options.orDie,
+          ZWorkerFactoryOptions.make.orDie,
+          ZTestEnvironmentOptions.make,
+          ZTestWorkflowEnvironment.make[Any]
+        )
+
+      ZIO
+        .serviceWith[ZTestWorkflowEnvironment[Any]] { env =>
+          // Registry must be None when a custom DataConverter is in use.
+          assertTrue(env.codecRegistry.isEmpty)
+        }
+        .provideSomeLayer[Scope](customEnvLayer)
+    }
+  )
+}

--- a/integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala
+++ b/integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala
@@ -92,9 +92,12 @@ object AutoRegistrationSpec extends ZIOSpecDefault {
         typeNames.count(_ == "java.lang.String") == 1
       )
     }.provideSomeLayer[Scope](emptyRegistryWorkflowEnv),
-    test("opt-out: when withDataConverter(raw) is used, the registry is None and auto-reg is a no-op") {
-      // Use a mock DataConverter that just echoes a fixed payload. The important thing is that setting it via
-      // withDataConverter clears codecRegistry to None, and auto-reg must then be a silent no-op.
+    test("opt-out: when withDataConverter(raw) is used, auto-reg at a call site is a silent no-op") {
+      // Use Temporal's stock DataConverter (Jackson-based) rather than our zio-json one. `withDataConverter`
+      // clears `codecRegistry` to `None`, so the macro-generated `None.foreach { r => r.register(...) }` body
+      // never runs — and crucially, this must succeed (not throw) even though the call site references a
+      // workflow interface and registry access would otherwise require `Some`. The worker creation returning
+      // normally is what the test asserts.
       val rawConverter = DefaultDataConverter.STANDARD_INSTANCE
       val options      =
         ZWorkflowClientOptions.make @@ ZWorkflowClientOptions.withDataConverter(rawConverter)
@@ -107,12 +110,19 @@ object AutoRegistrationSpec extends ZIOSpecDefault {
           ZTestWorkflowEnvironment.make[Any]
         )
 
-      ZIO
-        .serviceWith[ZTestWorkflowEnvironment[Any]] { env =>
-          // Registry must be None when a custom DataConverter is in use.
-          assertTrue(env.codecRegistry.isEmpty)
-        }
-        .provideSomeLayer[Scope](customEnvLayer)
+      (for {
+        env <- ZIO.service[ZTestWorkflowEnvironment[Any]]
+        // Registry must be None when a custom DataConverter is in use.
+        _ = assertTrue(env.codecRegistry.isEmpty)
+        // Exercising an auto-reg call site with a None registry must succeed — the macro-generated
+        // `None.foreach { r => r.register(...) }` body must compile and be inert at runtime.
+        _ <- ZTestWorkflowEnvironment.newWorker("opt-out-queue") @@
+               ZWorker.addWorkflow[SampleWorkflowImpl].fromClass @@
+               ZWorker.addActivityImplementation(new PromiseActivityImpl(x => x, x => x))
+        // The registry is still empty after the auto-reg sites ran.
+      } yield assertTrue(
+        env.codecRegistry.isEmpty
+      )).provideSomeLayer[Scope](customEnvLayer)
     }
   )
 }

--- a/integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala
+++ b/integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala
@@ -13,10 +13,9 @@ import zio.temporal.worker._
 import zio.temporal.workflow._
 import zio.test._
 
-/** End-to-end integration coverage for the auto-registration feature. Contrast with [[BaseTemporalSpec]] which
-  * wires every spec with the shared [[FixtureCodecRegistry.all]] — here we intentionally wire clients with an
-  * empty `CodecRegistry` to verify that the auto-reg call sites fill it in correctly at worker / stub-creation
-  * time.
+/** End-to-end integration coverage for the auto-registration feature. Contrast with [[BaseTemporalSpec]] which wires
+  * every spec with the shared [[FixtureCodecRegistry.all]] — here we intentionally wire clients with an empty
+  * `CodecRegistry` to verify that the auto-reg call sites fill it in correctly at worker / stub-creation time.
   */
 object AutoRegistrationSpec extends ZIOSpecDefault {
   override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
@@ -98,8 +97,7 @@ object AutoRegistrationSpec extends ZIOSpecDefault {
       // withDataConverter clears codecRegistry to None, and auto-reg must then be a silent no-op.
       val rawConverter = DefaultDataConverter.STANDARD_INSTANCE
       val options      =
-        ZWorkflowClientOptions
-          .make @@ ZWorkflowClientOptions.withDataConverter(rawConverter)
+        ZWorkflowClientOptions.make @@ ZWorkflowClientOptions.withDataConverter(rawConverter)
 
       val customEnvLayer: ULayer[ZTestWorkflowEnvironment[Any]] =
         ZLayer.make[ZTestWorkflowEnvironment[Any]](

--- a/integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala
+++ b/integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala
@@ -113,14 +113,14 @@ object AutoRegistrationSpec extends ZIOSpecDefault {
       (for {
         env <- ZIO.service[ZTestWorkflowEnvironment[Any]]
         // Registry must be None when a custom DataConverter is in use.
-        _ = assertTrue(env.codecRegistry.isEmpty)
+        registryClearedBeforeAutoReg = assertTrue(env.codecRegistry.isEmpty)
         // Exercising an auto-reg call site with a None registry must succeed — the macro-generated
         // `None.foreach { r => r.register(...) }` body must compile and be inert at runtime.
         _ <- ZTestWorkflowEnvironment.newWorker("opt-out-queue") @@
                ZWorker.addWorkflow[SampleWorkflowImpl].fromClass @@
                ZWorker.addActivityImplementation(new PromiseActivityImpl(x => x, x => x))
         // The registry is still empty after the auto-reg sites ran.
-      } yield assertTrue(
+      } yield registryClearedBeforeAutoReg && assertTrue(
         env.codecRegistry.isEmpty
       )).provideSomeLayer[Scope](customEnvLayer)
     }

--- a/testkit/src/main/scala/zio/temporal/testkit/ZTestActivityEnvironment.scala
+++ b/testkit/src/main/scala/zio/temporal/testkit/ZTestActivityEnvironment.scala
@@ -10,13 +10,17 @@ import zio.temporal.activity.{
 }
 import zio._
 import zio.temporal.{TypeIsSpecified}
-import zio.temporal.json.ZTemporalCodec
+import zio.temporal.json.{CodecRegistry, ZTemporalCodec}
 import zio.temporal.internal.ClassTagUtils
 import scala.reflect.ClassTag
 
 class ZTestActivityEnvironment[+R] private[zio] (
-  val toJava: TestActivityEnvironment,
-  runtime: zio.Runtime[R]) {
+  val toJava:                     TestActivityEnvironment,
+  runtime:                        zio.Runtime[R],
+  private[zio] val codecRegistry: Option[CodecRegistry]) {
+
+  /** Secondary constructor retained for call sites that don't have a registry reference. */
+  private[zio] def this(toJava: TestActivityEnvironment, runtime: zio.Runtime[R]) = this(toJava, runtime, None)
 
   implicit lazy val activityRunOptions: ZActivityRunOptions[R] =
     new ZActivityRunOptions[R](runtime, None)
@@ -236,12 +240,14 @@ object ZTestActivityEnvironment {
     ZLayer.scoped[R with ZTestEnvironmentOptions] {
       for {
         runtime <- ZIO.runtime[R with ZTestEnvironmentOptions]
-        env     <- ZIO.succeedBlocking(
+        env     <- ZIO.succeedBlocking {
+                 val envOptions = runtime.environment.get[ZTestEnvironmentOptions]
                  new ZTestActivityEnvironment[R](
-                   TestActivityEnvironment.newInstance(runtime.environment.get[ZTestEnvironmentOptions].toJava),
-                   runtime
+                   TestActivityEnvironment.newInstance(envOptions.toJava),
+                   runtime,
+                   envOptions.workflowClientOptions.codecRegistry
                  )
-               )
+               }
         _ <- ZIO.addFinalizer(
                ZIO.attempt(env.toJava.close()).ignore
              )

--- a/testkit/src/main/scala/zio/temporal/testkit/ZTestActivityEnvironment.scala
+++ b/testkit/src/main/scala/zio/temporal/testkit/ZTestActivityEnvironment.scala
@@ -15,8 +15,8 @@ import zio.temporal.internal.ClassTagUtils
 import scala.reflect.ClassTag
 
 class ZTestActivityEnvironment[+R] private[zio] (
-  val toJava:                     TestActivityEnvironment,
-  runtime:                        zio.Runtime[R],
+  val toJava: TestActivityEnvironment,
+  runtime:    zio.Runtime[R],
   private[zio] val codecRegistry: Option[CodecRegistry]) {
 
   /** Secondary constructor retained for call sites that don't have a registry reference. */

--- a/testkit/src/main/scala/zio/temporal/testkit/ZTestWorkflowEnvironment.scala
+++ b/testkit/src/main/scala/zio/temporal/testkit/ZTestWorkflowEnvironment.scala
@@ -30,8 +30,8 @@ import scala.reflect.ClassTag
   *   [[TestWorkflowEnvironment]]
   */
 class ZTestWorkflowEnvironment[+R] private[zio] (
-  val toJava:                     TestWorkflowEnvironment,
-  runtime:                        zio.Runtime[R],
+  val toJava: TestWorkflowEnvironment,
+  runtime:    zio.Runtime[R],
   private[zio] val codecRegistry: Option[CodecRegistry]) {
 
   /** Secondary constructor retained for call sites that don't have a registry reference. */
@@ -144,9 +144,8 @@ class ZTestWorkflowEnvironment[+R] private[zio] (
 
 object ZTestWorkflowEnvironment {
 
-  /** Internal helper used by the inline `newWorkflowStub[A]` (no-arg, deprecated) — wraps the testEnv access and
-    * the codec auto-reg thunk. Cannot be inline itself because the deprecated DSL class constructor is
-    * `private[zio]`.
+  /** Internal helper used by the inline `newWorkflowStub[A]` (no-arg, deprecated) — wraps the testEnv access and the
+    * codec auto-reg thunk. Cannot be inline itself because the deprecated DSL class constructor is `private[zio]`.
     */
   @zio.temporal.internalApi
   def buildTestEnvTaskQueueDsl[A: ClassTag](
@@ -207,8 +206,8 @@ object ZTestWorkflowEnvironment {
 
   /** Creates new typed workflow stub builder.
     *
-    * Auto-registration: auto-registers `A`'s codecs into the test env's registry (which is the same one shared
-    * with its embedded client and workers). Opt-out (`withDataConverter(raw)` → `None`) is a silent no-op.
+    * Auto-registration: auto-registers `A`'s codecs into the test env's registry (which is the same one shared with its
+    * embedded client and workers). Opt-out (`withDataConverter(raw)` → `None`) is a silent no-op.
     *
     * @tparam A
     *   workflow interface

--- a/testkit/src/main/scala/zio/temporal/testkit/ZTestWorkflowEnvironment.scala
+++ b/testkit/src/main/scala/zio/temporal/testkit/ZTestWorkflowEnvironment.scala
@@ -6,6 +6,7 @@ import zio.temporal.ZAwaitTerminationOptions
 import zio.temporal.activity.ZActivityRunOptions
 import zio.temporal.ZCurrentTimeMillis
 import zio.temporal.internal.TemporalWorkflowFacade
+import zio.temporal.json.CodecRegistry
 import zio.temporal.worker.ZWorker
 import zio.temporal.worker.ZWorkerOptions
 import zio.temporal.workflow._
@@ -21,10 +22,20 @@ import scala.reflect.ClassTag
   * is unit tested in milliseconds. Here is an example of a test that executes in a few milliseconds instead of over two
   * hours that are needed for the workflow to complete:
   *
+  * The `codecRegistry` field carries the same `CodecRegistry` instance supplied via
+  * `ZTestEnvironmentOptions.workflowClientOptions.codecRegistry`, so workers and stubs created through this env
+  * auto-register their codecs into it — matching the behaviour of the real `ZWorkflowClient` path.
+  *
   * @see
   *   [[TestWorkflowEnvironment]]
   */
-class ZTestWorkflowEnvironment[+R] private[zio] (val toJava: TestWorkflowEnvironment, runtime: zio.Runtime[R]) {
+class ZTestWorkflowEnvironment[+R] private[zio] (
+  val toJava:                     TestWorkflowEnvironment,
+  runtime:                        zio.Runtime[R],
+  private[zio] val codecRegistry: Option[CodecRegistry]) {
+
+  /** Secondary constructor retained for call sites that don't have a registry reference. */
+  private[zio] def this(toJava: TestWorkflowEnvironment, runtime: zio.Runtime[R]) = this(toJava, runtime, None)
 
   def namespace: String =
     toJava.getNamespace
@@ -36,11 +47,11 @@ class ZTestWorkflowEnvironment[+R] private[zio] (val toJava: TestWorkflowEnviron
     */
   def newWorker(taskQueue: String, options: ZWorkerOptions = ZWorkerOptions.default): UIO[ZWorker] =
     ZIO.succeedBlocking(
-      new ZWorker(toJava.newWorker(taskQueue, options.toJava))
+      new ZWorker(toJava.newWorker(taskQueue, options.toJava), codecRegistry)
     )
 
   /** Creates a WorkflowClient that is connected to the in-memory test Temporal service. */
-  lazy val workflowClient: ZWorkflowClient = new ZWorkflowClient(toJava.getWorkflowClient)
+  lazy val workflowClient: ZWorkflowClient = new ZWorkflowClient(toJava.getWorkflowClient, codecRegistry)
 
   /** Returns the in-memory test Temporal service that is owned by this. */
   lazy val workflowServiceStubs: ZWorkflowServiceStubs = new ZWorkflowServiceStubs(toJava.getWorkflowServiceStubs)
@@ -318,12 +329,14 @@ object ZTestWorkflowEnvironment {
   def make[R: Tag]: URLayer[R with ZTestEnvironmentOptions, ZTestWorkflowEnvironment[R]] =
     ZLayer.scoped[R with ZTestEnvironmentOptions] {
       ZIO.runtime[R with ZTestEnvironmentOptions].flatMap { runtime =>
-        ZIO.succeedBlocking(
+        ZIO.succeedBlocking {
+          val envOptions = runtime.environment.get[ZTestEnvironmentOptions]
           new ZTestWorkflowEnvironment[R](
-            TestWorkflowEnvironment.newInstance(runtime.environment.get[ZTestEnvironmentOptions].toJava),
-            runtime
+            TestWorkflowEnvironment.newInstance(envOptions.toJava),
+            runtime,
+            envOptions.workflowClientOptions.codecRegistry
           )
-        )
+        }
       }
     }
 

--- a/testkit/src/main/scala/zio/temporal/testkit/ZTestWorkflowEnvironment.scala
+++ b/testkit/src/main/scala/zio/temporal/testkit/ZTestWorkflowEnvironment.scala
@@ -144,6 +144,21 @@ class ZTestWorkflowEnvironment[+R] private[zio] (
 
 object ZTestWorkflowEnvironment {
 
+  /** Internal helper used by the inline `newWorkflowStub[A]` (no-arg, deprecated) — wraps the testEnv access and
+    * the codec auto-reg thunk. Cannot be inline itself because the deprecated DSL class constructor is
+    * `private[zio]`.
+    */
+  @zio.temporal.internalApi
+  def buildTestEnvTaskQueueDsl[A: ClassTag](
+    autoReg: ZTestWorkflowEnvironment[Any] => Unit
+  ): ZWorkflowStubBuilderTaskQueueDsl[URIO[ZTestWorkflowEnvironment[Any], ZWorkflowStub.Of[A]]] =
+    new ZWorkflowStubBuilderTaskQueueDsl[URIO[ZTestWorkflowEnvironment[Any], ZWorkflowStub.Of[A]]](options =>
+      ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
+        autoReg(testEnv)
+        TemporalWorkflowFacade.createWorkflowStubTyped[A](testEnv.workflowClient.toJava).apply(options)
+      }
+    )
+
   /** Setup test environment with a guaranteed finalization.
     *
     * @param options
@@ -190,7 +205,10 @@ object ZTestWorkflowEnvironment {
       ZIO.serviceWithZIO[ZTestWorkflowEnvironment[R]](testEnv => f(testEnv.activityRunOptions))
   }
 
-  /** Creates new typed workflow stub builder
+  /** Creates new typed workflow stub builder.
+    *
+    * Auto-registration: auto-registers `A`'s codecs into the test env's registry (which is the same one shared
+    * with its embedded client and workers). Opt-out (`withDataConverter(raw)` → `None`) is a silent no-op.
     *
     * @tparam A
     *   workflow interface
@@ -198,17 +216,17 @@ object ZTestWorkflowEnvironment {
     *   builder instance
     */
   @deprecated("Use newWorkflowStub accepting ZWorkerOptions", since = "0.6.0")
-  def newWorkflowStub[A: ClassTag: IsWorkflow]
+  inline def newWorkflowStub[A: ClassTag: IsWorkflow]
     : ZWorkflowStubBuilderTaskQueueDsl[URIO[ZTestWorkflowEnvironment[Any], ZWorkflowStub.Of[A]]] =
-    new ZWorkflowStubBuilderTaskQueueDsl[URIO[ZTestWorkflowEnvironment[Any], ZWorkflowStub.Of[A]]](options =>
-      ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
-        TemporalWorkflowFacade.createWorkflowStubTyped[A](testEnv.workflowClient.toJava).apply(options)
-      }
-    )
+    buildTestEnvTaskQueueDsl[A] { testEnv =>
+      zio.temporal.json.CodecRegistry.autoRegisterInterface[A](testEnv.codecRegistry)
+    }
 
   /** Creates workflow client stub that can be used to start a single workflow execution. The first call must be to a
     * method annotated with @[[zio.temporal.workflowMethod]]. After workflow is started it can be also used to send
     * signals or queries to it. one.
+    *
+    * Auto-registration: same contract as above. Applies to all `newWorkflowStub[A]` overloads on this object.
     *
     * @tparam A
     *   workflow interface
@@ -217,10 +235,11 @@ object ZTestWorkflowEnvironment {
     * @return
     *   builder instance
     */
-  def newWorkflowStub[A: ClassTag: IsWorkflow](
+  inline def newWorkflowStub[A: ClassTag: IsWorkflow](
     options: ZWorkflowOptions
   ): URIO[ZTestWorkflowEnvironment[Any], ZWorkflowStub.Of[A]] =
     ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
+      zio.temporal.json.CodecRegistry.autoRegisterInterface[A](testEnv.codecRegistry)
       TemporalWorkflowFacade.createWorkflowStubTyped[A](testEnv.workflowClient.toJava).apply(options.toJava)
     }
 
@@ -263,6 +282,8 @@ object ZTestWorkflowEnvironment {
 
   /** Creates workflow client stub for a known execution.
     *
+    * Auto-registration: same contract as the other overloads.
+    *
     * @tparam A
     *   interface that given workflow implements.
     * @param workflowId
@@ -272,7 +293,7 @@ object ZTestWorkflowEnvironment {
     * @return
     *   Stub that implements workflowInterface and can be used to signal or query it.
     */
-  def newWorkflowStub[A: ClassTag: IsWorkflow](
+  inline def newWorkflowStub[A: ClassTag: IsWorkflow](
     workflowId: String,
     runId:      Option[String] = None
   ): URIO[ZTestWorkflowEnvironment[Any], ZWorkflowStub.Of[A]] =


### PR DESCRIPTION
## Motivation

With the zio-json migration in PR #203, users had to manually chain `.addInterface[W]` / `.addInterface[A]` onto a `CodecRegistry` handed to `ZWorkflowClientOptions.withCodecRegistry(...)`:

```scala
val clientOptions =
  ZWorkflowClientOptions.make @@
    ZWorkflowClientOptions.withCodecRegistry(
      new CodecRegistry()
        .addInterface[PaymentWorkflow]
        .addInterface[PaymentActivity]
    )
```

That's boilerplate — the same workflow / activity types are already referenced at `worker.addWorkflow[W]` / `worker.addActivityImplementation(impl)` / `client.newWorkflowStub[W]` sites. This PR eliminates the boilerplate by auto-populating the registry at those call sites. Users just write `ZWorkflowClientOptions.make` and everything "just works."

## Call sites that now auto-register

Instance-side on `ZWorker`:
- `addWorkflow[I].fromClass` / `.fromClass(cls)` / `.from(f)` / `.from(cls, f)` — registers `I`'s codecs (macro walks to `@workflowInterface` ancestor when `I` is an impl class).
- `addActivityImplementation(impl)` — macro walks `impl`'s base classes for `@activityInterface` ancestors and registers each.
- `addActivityImplementations(List[...])` — each element's `registerCodecs` thunk (captured at `ZActivityImplementationObject[T]` construction time) runs against the worker's registry, solving the list-erasure problem.
- `addActivityImplementationService[A]`.

Object-side (`@@` aspect form): all the above aspects are `inline` and route through the instance-side inline methods, so they auto-register at the user's concrete call site.

Client / test-env side:
- `ZWorkflowClient.newWorkflowStub[A]` — all three overloads.
- `ZTestWorkflowEnvironment.newWorkflowStub[A]` — all three overloads.

The explicit `CodecRegistry.addInterface[I]` API stays supported for opt-in control and for types that don't flow through a stub/worker (e.g. heartbeat details, `Workflow.retry` internals, sealed-trait parents). See `FixtureCodecRegistry.all` in `integration-tests` — kept intact.

## Fail-fast check removal

`ZWorkflowClient.make` used to reject an empty `CodecRegistry` at client construction. With auto-reg that guarantee no longer holds — the registry starts empty and fills up incrementally as workers/stubs are created. The check is removed. Users who forget to register any workflow/activity type will still get a clear `"No ZTemporalCodec registered for runtime class …"` error at first payload encode (already well-designed in `ZioJsonPayloadConverter`).

This is a slight relaxation — previously you'd get an error at client construction; now you get one at first encode.

## Opt-out: `withDataConverter(raw)`

When the user supplies a custom `DataConverter` via `.withDataConverter(...)`, `ZWorkflowClientOptions.codecRegistry` is cleared to `None`. The auto-reg macros expand to `registryOpt.foreach { r => r.register(...) }`; with `None` the `foreach` body never runs — a silent no-op that leaves full control to the foreign converter. Covered by the opt-out integration test.

## Design decision: Option A

Per the scoping doc I took **Option A**: the registry reference is threaded into each Scala wrapper (`ZWorkflowClient`, `ZWorkerFactory`, `ZWorker`, `ZTestWorkflowEnvironment`, `ZTestActivityEnvironment`). The registry is the same `ConcurrentHashMap`-backed instance that `ZioJsonPayloadConverter` captures by constructor reference — so mutations at worker/stub time are immediately visible to encode/decode.

Option B (implicit / ZIO service threading) was not needed — the plumbing was mechanical and each wrapper already had `private[zio]` constructors making the field addition non-breaking.

## Trade-off: auto-reg is non-strict

The explicit `addInterface[I]` path remains strict — a missing `ZTemporalCodec` aborts compilation. The new auto-reg path (`autoRegisterInterface[I]`) is **non-strict**: referenced types without a summonable codec are silently skipped rather than aborting.

Rationale: `UnionTypeWorkflowSpec` fixtures have methods taking `Int | Null` / `String | Null` / similar Scala 3 union types that intentionally erase to `Object` and have no codec by design. Forcing strict would break those fixtures' compilation as soon as the auto-reg macro runs for them. A runtime `"No ZTemporalCodec registered for …"` will still fire if a user actually tries to serialize such a value.

Users who want the strict check can still call `.addInterface[I]` explicitly.

## Test plan

### Core unit tests
`core/src/test/scala/zio/temporal/json/CodecRegistryAutoRegisterSpec.scala` — 8 tests:
- [x] `autoRegisterInterface[I]` populates `Some(registry)` with every boundary-method type
- [x] `autoRegisterInterface[I]` is a silent no-op when registry is `None`
- [x] `autoRegisterInterface[I]` is idempotent on repeated calls
- [x] `autoRegisterInterface[I]` walks to `@workflowInterface` ancestor when given an impl class
- [x] `autoRegisterInterface[I]` silently skips uncodec-able types (non-strict mode)
- [x] `autoRegisterActivityImpl[A]` registers the `@activityInterface` ancestor's codecs
- [x] `autoRegisterActivityImpl[A]` is a silent no-op when registry is `None`
- [x] `autoRegisterActivityImpl[A]` handles multi-interface impls

### Integration tests
`integration-tests/src/test/scala/zio/temporal/AutoRegistrationSpec.scala` — 4 tests:
- [x] Workflow round-trips end-to-end via `addWorkflow[Impl].fromClass` + `newWorkflowStub[Workflow]` with zero manual `.addInterface[...]`.
- [x] Activity round-trips via `addActivityImplementation(impl)`.
- [x] Idempotency: same workflow registered on three workers yields one codec entry in the shared registry.
- [x] Opt-out: `withDataConverter(raw)` → `codecRegistry = None`; exercises the auto-reg call sites (`addWorkflow`, `addActivityImplementation` aspects) and verifies they succeed as silent no-ops and the registry stays empty.

### Regression coverage
All existing tests (core: 111; integration-tests: 69 ZIO + 25 ScalaTest) continue to pass unchanged. `FixtureCodecRegistry.all` is kept intact for types that don't flow through the instrumented call sites (heartbeat details, sealed-trait parents promoted by the macro).

## Verification

- `sbt --client "core/test"` — 111 tests pass (103 pre-existing + 8 new).
- `sbt --client "integration-tests/test"` — 69 ZIO + 25 ScalaTest tests pass (65 + 25 pre-existing + 4 new ZIO).
- `sbt --client scalafmtCheckAll` — clean.
- `sbt --client "examples/compile"` — **FAILS on base too**. Pre-existing, unrelated to this PR. `ProtobufParameterizedWorkflowMain.scala` calls `.addInterface[SodaChildWorkflow]` for a workflow whose input type (`ChildWorkflowInput.NonEmpty`) lacks a `ZTemporalCodec` — a fixture gap in the protobuf example, not an auto-reg regression. Worth fixing separately.

## Known follow-ups

- **`addWorkflowImplementations(List[...])` (plural form) is not instrumented.** Users on that path still need explicit `.addInterface[...]`. Parallel fix would be to carry a `registerCodecs` thunk on `ZWorkflowImplementationClass[T]` the same way this PR does for `ZActivityImplementationObject[T]`. Not in scope for this PR.
- **`ZTestActivityEnvironment.addActivityImplementation`** isn't wired into auto-reg yet. Test-env parity cleanup.
- **CI-level examples fix.** The pre-existing `examples/compile` failure mentioned above needs its own PR.

## Breaking-change assessment

- All user-facing public method signatures of `addWorkflow[I]`, `newWorkflowStub[A]`, `addActivityImplementation[A]`, etc. remain **source-compatible**. Auto-reg is purely additive behaviour.
- The explicit `.addInterface[I]` API on `CodecRegistry` is unchanged.
- `ZWorkflowClient`, `ZWorker`, `ZWorkerFactory`, `ZTestWorkflowEnvironment`, `ZTestActivityEnvironment` gain a `private[zio] val codecRegistry: Option[CodecRegistry]` — primary constructors are `private[zio]`, so this is internal. Secondary no-op constructors preserve the old shape for the rare direct caller that doesn't have a registry.
- `ZActivityImplementationObject[T]` gains a `private[zio] val registerCodecs: Option[CodecRegistry] => Unit` field with a no-op secondary constructor for backward compatibility.
- **Fail-fast check removal in `ZWorkflowClient.make`** is a slight relaxation of the old contract. Error moves from construction time to first-encode time; the error message is at least as precise.