### PR TITLE
fix: get the docs site actually building again

### DIFF
--- a/docs/src/main/mdoc/observability.md
+++ b/docs/src/main/mdoc/observability.md
@@ -260,7 +260,7 @@ ZIO Temporal encodes a lot of custom types on top of those supported by Temporal
 - `Option`
 - Scala collections (`Set`, `List`, `Array`, etc.)
 - Some `java.time` classes (`Instant`, `LocalDateTime`, `OffsetDateTime`)
-- `Enumeratum` enums, `Scala 3` enums (as `keyword`)
+- `Scala 3` enums (as `keyword`)
 
 Note that `String` can be encoded both as `text` and `keyword`. By default, it's `text`. If you need it to be encoded
 as `keyword`, you must wrap it into `ZSearchAttribute.keyword` method.  
@@ -282,30 +282,8 @@ val searchAttributes: Map[String, ZSearchAttribute] =
   )
 ```
 
-`Enumeratum` enum example:
+`Scala 3` enum example:
 
-```scala mdoc:reset
-import enumeratum.{Enum, EnumEntry}
-import zio.temporal._
-import zio.temporal.enumeratum._
-
-sealed trait Color extends EnumEntry
-object Color extends Enum[Color] {
-  case object Red extends Color
-  case object Green extends Color
-  case object Blue extends Color
-
-  override val values = findValues
-}
-
-val otherSearchAttributes: Map[String, ZSearchAttribute] = Map(
-  "EnumAttr"    -> ZSearchAttribute.keyword[Color](Color.Green),
-  "OptionEnum"  -> ZSearchAttribute.keyword(Option[Color](Color.Red)),
-  "OptionEnum2" -> ZSearchAttribute.keyword(Option.empty[Color])
-)
-```
-
-Same example with `Scala 3` enums
 ```scala
 import zio.temporal._
 

--- a/project/BuildConfig.scala
+++ b/project/BuildConfig.scala
@@ -109,12 +109,13 @@ trait Dependencies {
 
   object Monitoring {
     val otelApi              = "io.opentelemetry"         % "opentelemetry-api"                         % versions.otel
+    val otelSdk              = "io.opentelemetry"         % "opentelemetry-sdk"                         % versions.otel
     val otelExporterOtlp     = "io.opentelemetry"         % "opentelemetry-exporter-otlp"               % versions.otel
     val otelTracePropagators = "io.opentelemetry"         % "opentelemetry-extension-trace-propagators" % versions.otel
     val otelOpentracingShim  = "io.opentelemetry"         % "opentelemetry-opentracing-shim"            % versions.otel
     val otelSemvonc          = "io.opentelemetry.semconv" % "opentelemetry-semconv"                     % "1.43.0"
 
-    val otel = Seq(otelApi, otelExporterOtlp, otelTracePropagators, otelOpentracingShim, otelSemvonc)
+    val otel = Seq(otelApi, otelSdk, otelExporterOtlp, otelTracePropagators, otelOpentracingShim, otelSemvonc)
 
     val micrometerOtlp = "io.micrometer" % "micrometer-registry-otlp" % "1.17.0"
   }

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
     "@docusaurus/core": "^3.5.2",
     "@docusaurus/preset-classic": "^3.5.2",
     "@docusaurus/theme-mermaid": "^3.5.2",
+    "@mermaid-js/layout-elk": "^0.1.9",
     "clsx": "^1.1.1",
     "prism-react-renderer": "^2.4.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

Follow-up to #262. Triggered the Site workflow manually to confirm the GitHub Pages deploy works end-to-end and found it fails at the `Generate site` step — three independent, pre-existing breaks the regular CI matrix never catches (mdoc/docusaurus aren't part of `sbt +test`, and the Site workflow itself only runs on `release`/`workflow_dispatch`).

## What's broken and why

- **`docs/observability.md`'s "Enumeratum enum example"** imports `zio.temporal.enumeratum`, a package that was deleted in the Scala-3-only migration (#128) years ago. The doc was never updated. Dropped the dead example — the `Scala 3` enum example right below it already covers the supported path.
- **Same file uses `OpenTelemetrySdk`**, which lives in the `opentelemetry-sdk` artifact. That artifact was never listed in `Monitoring.otel` — only ever resolved transitively, until the otel 1.61.0 → 1.65.0 bump (#259) dropped that transitive edge. (Same root cause as an `examples/compile` break I fixed separately on the `1.x` branch — `docs` pulls in `examplesLibs`, so it hit here too.)
- **`website/package.json` never declared `@mermaid-js/layout-elk`**, an optional peer dependency `@docusaurus/theme-mermaid` 3.10.2 now statically imports. Webpack fails the client bundle without it.

Also: tried converting the Scala 3 enum example to an executable `scala mdoc` block (to actually verify it), but Scala 3's compiler-generated enum `valueOf`/`values` lookup breaks specifically inside mdoc's generated wrapper-object nesting — the equivalent code works fine one level of nesting deep, which is exactly what the real, passing `EnumSearchAttributesSpec` test does. Not worth chasing right now, so it's back to a plain illustrative fence like it always was.

## Test plan

- [x] `sbt unidoc` — green (scaladoc → `website/static/api`)
- [x] `sbt docs/mdoc` — green, 0 errors
- [x] `npm run build` (in `website/`) — green, static site generated
- [x] Confirmed the fork's branding (from #262) shows up correctly in the generated output